### PR TITLE
fix: handle "drop_down" type for custom field resolution

### DIFF
--- a/pkg/cmd/task/custom_fields.go
+++ b/pkg/cmd/task/custom_fields.go
@@ -48,7 +48,7 @@ func parseFieldValue(field *clickup.CustomField, rawValue string) (interface{}, 
 			return nil, fmt.Errorf("invalid checkbox value %q for field %q (use true/false)", rawValue, field.Name)
 		}
 
-	case "dropdown":
+	case "dropdown", "drop_down":
 		return resolveDropdownOption(field, rawValue)
 
 	case "labels":
@@ -262,7 +262,7 @@ func formatCustomFieldValue(field clickup.CustomField) string {
 			}
 		}
 
-	case "dropdown":
+	case "dropdown", "drop_down":
 		return formatDropdownValue(field)
 
 	case "labels":


### PR DESCRIPTION
## Summary

- The ClickUp API returns dropdown field types as `"drop_down"` (with underscore), but `parseFieldValue` and `formatCustomFieldValue` only match `"dropdown"` (without underscore)
- This causes `--field` to fall through to the `default` case, sending the raw display name (e.g. `"Bug"`) instead of the resolved UUID
- The API rejects this with `400 Value must be an option index or uuid FIELD_011`

Two-line fix: add `"drop_down"` as an alias in both switch statements.

## Reproduction

```bash
clickup task create --list-id <any-list> --name "Test" --field "Task Type=Bug"
# Error: task created but failed to set custom field "Task Type": ... 400 Value must be an option index or uuid
```

## Test

After fix:
```bash
clickup task create --list-id <list> --name "Test" --field "Task Type=Bug"
# Success: task created with Task Type field correctly set
```