### PR TITLE
feat: contextual folder and list management, include closed tasks

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	Workspace         string                       `yaml:"workspace,omitempty"`
 	Space             string                       `yaml:"space,omitempty"`
 	SprintFolder      string                       `yaml:"sprint_folder,omitempty"`
+	Folder            string                       `yaml:"folder,omitempty"`
+	List              string                       `yaml:"list,omitempty"`
 	Editor            string                       `yaml:"editor,omitempty"`
 	Prompt            string                       `yaml:"prompt,omitempty"`
 	Aliases           map[string]string            `yaml:"aliases,omitempty"`
@@ -20,7 +22,9 @@ type Config struct {
 
 // DirectoryConfig holds per-directory overrides.
 type DirectoryConfig struct {
-	Space string `yaml:"space,omitempty"`
+	Space  string `yaml:"space,omitempty"`
+	Folder string `yaml:"folder,omitempty"`
+	List   string `yaml:"list,omitempty"`
 }
 
 // ConfigDir returns the path to the config directory (~/.config/clickup).
@@ -81,6 +85,26 @@ func (c *Config) SpaceForDir(dir string) string {
 		}
 	}
 	return c.Space
+}
+
+// FolderForDir returns the folder override for a specific directory, falling back to the global default.
+func (c *Config) FolderForDir(dir string) string {
+	if c.DirectoryDefaults != nil {
+		if dc, ok := c.DirectoryDefaults[dir]; ok && dc.Folder != "" {
+			return dc.Folder
+		}
+	}
+	return c.Folder
+}
+
+// ListForDir returns the list override for a specific directory, falling back to the global default.
+func (c *Config) ListForDir(dir string) string {
+	if c.DirectoryDefaults != nil {
+		if dc, ok := c.DirectoryDefaults[dir]; ok && dc.List != "" {
+			return dc.List
+		}
+	}
+	return c.List
 }
 
 // SetDirectoryDefault sets a per-directory config override.

--- a/internal/iostreams/color.go
+++ b/internal/iostreams/color.go
@@ -87,7 +87,7 @@ func (c *ColorScheme) StatusColor(status string) func(string) string {
 		return c.Gray
 	case "in progress", "in review":
 		return c.Blue
-	case "done", "complete", "closed":
+	case "done", "complete", "completed", "closed":
 		return c.Green
 	default:
 		return c.Yellow

--- a/pkg/cmd/folder/folder.go
+++ b/pkg/cmd/folder/folder.go
@@ -1,0 +1,20 @@
+package folder
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolder returns the folder parent command.
+func NewCmdFolder(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "folder",
+		Short: "Manage folders",
+		Long:  "List folders in your ClickUp spaces.",
+	}
+
+	cmd.AddCommand(NewCmdFolderList(f))
+	cmd.AddCommand(NewCmdFolderSelect(f))
+
+	return cmd
+}

--- a/pkg/cmd/folder/list.go
+++ b/pkg/cmd/folder/list.go
@@ -1,0 +1,70 @@
+package folder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/tableprinter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolderList returns the folder list command.
+func NewCmdFolderList(f *cmdutil.Factory) *cobra.Command {
+	var jsonFlags cmdutil.JSONFlags
+	var spaceID string
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List folders in a space",
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			targetSpace := spaceID
+			if targetSpace == "" {
+				targetSpace = cfg.Space
+			}
+
+			if targetSpace == "" {
+				return fmt.Errorf("no space specified or configured. Use --space or run 'clickup space select'")
+			}
+
+			folders, _, err := client.Clickup.Folders.GetFolders(context.Background(), targetSpace, false)
+			if err != nil {
+				return fmt.Errorf("failed to fetch folders: %w", err)
+			}
+
+			if jsonFlags.WantsJSON() {
+				return jsonFlags.OutputJSON(f.IOStreams.Out, folders)
+			}
+
+			if len(folders) == 0 {
+				fmt.Fprintln(f.IOStreams.Out, "No folders found.")
+				return nil
+			}
+
+			tp := tableprinter.New(f.IOStreams)
+
+			for _, folder := range folders {
+				tp.AddField(folder.ID)
+				tp.AddField(folder.Name)
+				tp.EndRow()
+			}
+
+			return tp.Render()
+		},
+	}
+
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space)")
+	cmdutil.AddJSONFlags(cmd, &jsonFlags)
+	return cmd
+}

--- a/pkg/cmd/folder/select.go
+++ b/pkg/cmd/folder/select.go
@@ -1,0 +1,104 @@
+package folder
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/prompter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolderSelect returns the folder select command.
+func NewCmdFolderSelect(f *cmdutil.Factory) *cobra.Command {
+	var local bool
+
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Select an active folder",
+		Long: `Interactively select a folder to be your default.
+
+When you select a folder, 'clickup list list' will automatically
+show lists from this folder.
+
+If --local is provided, the folder is set only for the current directory.
+Otherwise, it sets the global default folder.`,
+		Example: `  # Select a global default folder
+  clickup folder select
+
+  # Select a default folder only for the current directory
+  clickup folder select --local`,
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			targetSpace := cfg.Space
+			if targetSpace == "" {
+				return fmt.Errorf("no space configured. Run 'clickup space select' first")
+			}
+
+			folders, _, err := client.Clickup.Folders.GetFolders(context.Background(), targetSpace, false)
+			if err != nil {
+				return fmt.Errorf("failed to fetch folders: %w", err)
+			}
+
+			if len(folders) == 0 {
+				return fmt.Errorf("no folders found in the configured space")
+			}
+
+			p := prompter.New(f.IOStreams)
+			names := make([]string, len(folders))
+			folderMap := make(map[string]string)
+
+			for i, folder := range folders {
+				displayName := fmt.Sprintf("%s (%s)", folder.Name, folder.ID)
+				names[i] = displayName
+				folderMap[displayName] = folder.ID
+			}
+
+			idx, err := p.Select("Select a folder", names)
+			if err != nil {
+				return err
+			}
+
+			selectedName := names[idx]
+			selectedID := folderMap[selectedName]
+
+			if local {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+
+				dc := cfg.DirectoryDefaults[cwd]
+				dc.Folder = selectedID
+				cfg.SetDirectoryDefault(cwd, dc)
+
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("failed to save config: %w", err)
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Saved local default folder: %s\n", selectedName)
+			} else {
+				cfg.Folder = selectedID
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("failed to save config: %w", err)
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Saved global default folder: %s\n", selectedName)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&local, "local", false, "Set folder only for the current directory")
+
+	return cmd
+}

--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -1,0 +1,20 @@
+package list
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdList returns the list parent command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Manage lists",
+		Long:  "List ClickUp lists in your spaces or folders.",
+	}
+
+	cmd.AddCommand(NewCmdListList(f))
+	cmd.AddCommand(NewCmdListSelect(f))
+
+	return cmd
+}

--- a/pkg/cmd/list/list_list.go
+++ b/pkg/cmd/list/list_list.go
@@ -1,0 +1,93 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/tableprinter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+	"github.com/raksul/go-clickup/clickup"
+)
+
+// NewCmdListList returns the list list command.
+func NewCmdListList(f *cmdutil.Factory) *cobra.Command {
+	var jsonFlags cmdutil.JSONFlags
+	var spaceID string
+	var folderID string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List lists in a space or folder",
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			var lists []clickup.List
+
+			targetFolder := folderID
+			if targetFolder == "" {
+				cwd, _ := os.Getwd()
+				targetFolder = cfg.FolderForDir(cwd)
+			}
+
+			if targetFolder != "" {
+				// Get lists in a specific folder
+				fetchedLists, _, err := client.Clickup.Lists.GetLists(context.Background(), targetFolder, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch lists for folder: %w", err)
+				}
+				lists = fetchedLists
+			} else {
+				// Get folderless lists in a space
+				targetSpace := spaceID
+				if targetSpace == "" {
+					targetSpace = cfg.Space
+				}
+
+				if targetSpace == "" {
+					return fmt.Errorf("no space or folder specified. Use --space, --folder, or run 'clickup space select'")
+				}
+
+				fetchedLists, _, err := client.Clickup.Lists.GetFolderlessLists(context.Background(), targetSpace, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch folderless lists for space: %w", err)
+				}
+				lists = fetchedLists
+			}
+
+			if jsonFlags.WantsJSON() {
+				return jsonFlags.OutputJSON(f.IOStreams.Out, lists)
+			}
+
+			if len(lists) == 0 {
+				fmt.Fprintln(f.IOStreams.Out, "No lists found.")
+				return nil
+			}
+
+			tp := tableprinter.New(f.IOStreams)
+
+			for _, list := range lists {
+				tp.AddField(list.ID)
+				tp.AddField(list.Name)
+				tp.EndRow()
+			}
+
+			return tp.Render()
+		},
+	}
+
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space)")
+	cmd.Flags().StringVar(&folderID, "folder", "", "Folder ID (lists inside a specific folder)")
+	cmdutil.AddJSONFlags(cmd, &jsonFlags)
+	return cmd
+}

--- a/pkg/cmd/list/select.go
+++ b/pkg/cmd/list/select.go
@@ -1,0 +1,132 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/prompter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdListSelect returns the list select command.
+func NewCmdListSelect(f *cmdutil.Factory) *cobra.Command {
+	var local bool
+	var folderID string
+
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Select an active list",
+		Long: `Interactively select a list to be your default.
+
+The selected list will be used by default for task commands.
+
+If --local is provided, the list is set only for the current directory.
+Otherwise, it sets the global default list.`,
+		Example: `  # Select a global default list
+  clickup list select
+
+  # Select a list from a specific folder
+  clickup list select --folder 12345
+
+  # Select a default list only for the current directory
+  clickup list select --local`,
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			targetSpace := cfg.Space
+			
+			targetFolder := folderID
+			if targetFolder == "" {
+				cwd, _ := os.Getwd()
+				targetFolder = cfg.FolderForDir(cwd)
+			}
+			
+			if targetSpace == "" && targetFolder == "" {
+				return fmt.Errorf("no space or folder configured. Run 'clickup space select' or 'clickup folder select' first")
+			}
+
+			// For simplicity in interactive selection, we fetch lists depending on folder vs space.
+			var listsMap map[string]string = make(map[string]string)
+			var listNames []string
+
+			if targetFolder != "" {
+				lists, _, err := client.Clickup.Lists.GetLists(context.Background(), targetFolder, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch lists for folder: %w", err)
+				}
+				for _, list := range lists {
+					listsMap[list.Name] = list.ID
+					listNames = append(listNames, list.Name)
+				}
+			} else {
+				// To keep it simple, just fetching folderless lists for space.
+				lists, _, err := client.Clickup.Lists.GetFolderlessLists(context.Background(), targetSpace, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch lists for space: %w", err)
+				}
+				for _, list := range lists {
+					listsMap[list.Name] = list.ID
+					listNames = append(listNames, list.Name)
+				}
+			}
+
+			if len(listNames) == 0 {
+				return fmt.Errorf("no lists found in the selected space/folder")
+			}
+
+			p := prompter.New(f.IOStreams)
+			names := make([]string, len(listNames))
+			for i, name := range listNames {
+				names[i] = fmt.Sprintf("%s (%s)", name, listsMap[name])
+			}
+
+			idx, err := p.Select("Select a list", names)
+			if err != nil {
+				return err
+			}
+
+			selectedName := listNames[idx]
+			selectedID := listsMap[selectedName]
+
+			if local {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+
+				dc := cfg.DirectoryDefaults[cwd]
+				dc.List = selectedID
+				cfg.SetDirectoryDefault(cwd, dc)
+
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("failed to save config: %w", err)
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Saved local default list: %s (%s)\n", selectedName, selectedID)
+			} else {
+				cfg.List = selectedID
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("failed to save config: %w", err)
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Saved global default list: %s (%s)\n", selectedName, selectedID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&local, "local", false, "Set list only for the current directory")
+	cmd.Flags().StringVar(&folderID, "folder", "", "Folder ID to search lists in")
+
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -12,6 +12,8 @@ import (
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/link"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/member"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/space"
+	"github.com/triptechtravel/clickup-cli/pkg/cmd/folder"
+	listcmd "github.com/triptechtravel/clickup-cli/pkg/cmd/list"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/sprint"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/status"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/tag"
@@ -47,6 +49,8 @@ Links GitHub PRs, branches, and commits to ClickUp tasks.`,
 	cmd.AddCommand(link.NewCmdLink(f))
 	cmd.AddCommand(sprint.NewCmdSprint(f))
 	cmd.AddCommand(space.NewCmdSpace(f))
+	cmd.AddCommand(folder.NewCmdFolder(f))
+	cmd.AddCommand(listcmd.NewCmdList(f))
 	cmd.AddCommand(field.NewCmdField(f))
 	cmd.AddCommand(tag.NewCmdTag(f))
 

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/raksul/go-clickup/clickup"
@@ -12,12 +13,13 @@ import (
 )
 
 type listOptions struct {
-	listID    string
-	assignee  []string
-	status    []string
-	sprint    string
-	page      int
-	jsonFlags cmdutil.JSONFlags
+	listID        string
+	assignee      []string
+	status        []string
+	sprint        string
+	page          int
+	includeClosed bool
+	jsonFlags     cmdutil.JSONFlags
 }
 
 // NewCmdList returns a command to list ClickUp tasks in a given list.
@@ -39,19 +41,28 @@ Results can be filtered by assignee, status, and sprint.`,
 		PersistentPreRunE: cmdutil.NeedsAuth(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.listID == "" {
-				return fmt.Errorf("required flag --list-id not set")
+				cfg, err := f.Config()
+				if err != nil {
+					return err
+				}
+
+				cwd, _ := os.Getwd()
+				opts.listID = cfg.ListForDir(cwd)
+
+				if opts.listID == "" {
+					return fmt.Errorf("required flag --list-id not set and no default list configured")
+				}
 			}
 			return runList(f, opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.listID, "list-id", "", "ClickUp list ID (required)")
+	cmd.Flags().StringVar(&opts.listID, "list-id", "", "ClickUp list ID (defaults to configured list)")
 	cmd.Flags().StringSliceVar(&opts.assignee, "assignee", nil, `Filter by assignee ID(s), or "me" for yourself`)
 	cmd.Flags().StringSliceVar(&opts.status, "status", nil, "Filter by status(es)")
 	cmd.Flags().StringVar(&opts.sprint, "sprint", "", "Filter by sprint name")
 	cmd.Flags().IntVar(&opts.page, "page", 0, "Page number for pagination (starts at 0)")
-
-	_ = cmd.MarkFlagRequired("list-id")
+	cmd.Flags().BoolVarP(&opts.includeClosed, "include-closed", "c", false, "Include closed/completed tasks")
 
 	cmdutil.AddJSONFlags(cmd, &opts.jsonFlags)
 
@@ -67,7 +78,8 @@ func runList(f *cmdutil.Factory, opts *listOptions) error {
 	}
 
 	taskOpts := &clickup.GetTasksOptions{
-		Page: opts.page,
+		Page:          opts.page,
+		IncludeClosed: opts.includeClosed,
 	}
 
 	if len(opts.status) > 0 {
@@ -141,7 +153,12 @@ func printTaskTable(f *cmdutil.Factory, tasks []clickup.Task) error {
 		tp.AddField(t.Name)
 
 		statusText := t.Status.Status
-		statusColorFn := cs.StatusColor(strings.ToLower(statusText))
+		var statusColorFn func(string) string
+		if t.Status.Type == "closed" || t.Status.Type == "done" {
+			statusColorFn = cs.Green
+		} else {
+			statusColorFn = cs.StatusColor(strings.ToLower(statusText))
+		}
 		tp.AddField(statusColorFn(statusText))
 
 		tp.AddField(t.Priority.Priority)


### PR DESCRIPTION
## Motivation
Navigating ClickUp's deep hierarchy (Space -> Folder -> List) manually via IDs is tedious. Previously, users had to constantly look up and supply the --list-id to view tasks. Additionally, the CLI silently dropped closed tasks due to default API behavior, and custom-named completed statuses weren't colorized properly.

This PR introduces a contextual workflow that allows users to "stay on" a specific folder or list (globally or per-directory) and adds the missing folder/list traversal commands.

## Changes:
   - Folder Management: Added clickup folder list and clickup folder select commands.
   - List Management: Added clickup list list and clickup list select commands.
   - Contextual Config: Config system now supports Folder and List persistence.
   - Per-Directory Scoping: Added --local flag to select commands, allowing users to bind specific directories to specific ClickUp lists.
   - Task List Overhaul:
     - clickup task list now automatically inherits the active listID from config if --list-id is omitted.
     - Added -c / --include-closed flag to fetch closed/completed tasks.
   - UI Polish: Console printer now inspects the underlying Status.Type (e.g., closed, done) rather than just the text string, ensuring completed tasks are always highlighted green regardless
     of custom status names.

  ## Example New Workflow:

   - Interactively set the context for the current project directory
      - `clickup folder select --local`
      - `clickup list select --local`
   -  Fetch tasks seamlessly without needing IDs (including closed tasks)
      - `clickup task list -c`