### PR TITLE
feat: folder and list management, contextual task list

### DIFF
--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -17,7 +17,7 @@ Flag details, examples, and options for each command are in the auto-generated [
 |---------|-------------|
 | [`task activity`](/clickup-cli/reference/clickup_task_activity/) | View a task's details and comment history |
 | [`task create`](/clickup-cli/reference/clickup_task_create/) | Create a new ClickUp task |
-| [`task delete`](/clickup-cli/reference/clickup_task_delete/) | Delete a task |
+| [`task delete`](/clickup-cli/reference/clickup_task_delete/) | Delete one or more tasks |
 | [`task edit`](/clickup-cli/reference/clickup_task_edit/) | Edit a ClickUp task |
 | [`task list`](/clickup-cli/reference/clickup_task_list/) | List tasks in a ClickUp list |
 | [`task list-add`](/clickup-cli/reference/clickup_task_list-add/) | Add tasks to an additional list |
@@ -122,7 +122,7 @@ Flag details, examples, and options for each command are in the auto-generated [
 
 | Command | Description |
 |---------|-------------|
-| [`inbox`](/clickup-cli/reference/clickup_inbox/) | Show recent @mentions |
+| [`inbox`](/clickup-cli/reference/clickup_inbox/) | Show recent @mentions and assignments |
 | [`member list`](/clickup-cli/reference/clickup_member_list/) | List workspace members |
 | [`space list`](/clickup-cli/reference/clickup_space_list/) | List spaces in your workspace |
 | [`space select`](/clickup-cli/reference/clickup_space_select/) | Set default space |

--- a/docs/src/content/docs/reference/clickup.md
+++ b/docs/src/content/docs/reference/clickup.md
@@ -26,8 +26,10 @@ Links GitHub PRs, branches, and commits to ClickUp tasks.
 * [clickup completion](/clickup-cli/reference/clickup_completion/)	 - Generate shell completion scripts
 * [clickup doc](/clickup-cli/reference/clickup_doc/)	 - Manage ClickUp Docs
 * [clickup field](/clickup-cli/reference/clickup_field/)	 - Manage custom fields
-* [clickup inbox](/clickup-cli/reference/clickup_inbox/)	 - Show recent @mentions
+* [clickup folder](/clickup-cli/reference/clickup_folder/)	 - Manage folders
+* [clickup inbox](/clickup-cli/reference/clickup_inbox/)	 - Show recent @mentions and assignments
 * [clickup link](/clickup-cli/reference/clickup_link/)	 - Link GitHub objects to ClickUp tasks
+* [clickup list](/clickup-cli/reference/clickup_list/)	 - Manage lists
 * [clickup member](/clickup-cli/reference/clickup_member/)	 - Manage workspace members
 * [clickup space](/clickup-cli/reference/clickup_space/)	 - Manage spaces
 * [clickup sprint](/clickup-cli/reference/clickup_sprint/)	 - Manage sprints

--- a/docs/src/content/docs/reference/clickup_folder.md
+++ b/docs/src/content/docs/reference/clickup_folder.md
@@ -1,0 +1,23 @@
+---
+title: "clickup folder"
+description: "Auto-generated reference for clickup folder"
+---
+
+Manage folders
+
+### Synopsis
+
+List and select ClickUp folders in a space.
+
+### Options
+
+```
+  -h, --help   help for folder
+```
+
+### SEE ALSO
+
+* [clickup](/clickup-cli/reference/clickup/)	 - ClickUp CLI - manage tasks from the command line
+* [clickup folder list](/clickup-cli/reference/clickup_folder_list/)	 - List folders in a space
+* [clickup folder select](/clickup-cli/reference/clickup_folder_select/)	 - Set default folder
+

--- a/docs/src/content/docs/reference/clickup_folder_list.md
+++ b/docs/src/content/docs/reference/clickup_folder_list.md
@@ -1,0 +1,44 @@
+---
+title: "clickup folder list"
+description: "Auto-generated reference for clickup folder list"
+---
+
+List folders in a space
+
+### Synopsis
+
+List all folders in a ClickUp space.
+
+```
+clickup folder list [flags]
+```
+
+### Examples
+
+```
+  # List folders in your default space
+  clickup folder list
+
+  # List folders in a specific space
+  clickup folder list --space 12345
+
+  # Include archived folders
+  clickup folder list --archived
+```
+
+### Options
+
+```
+      --archived          Include archived folders
+  -h, --help              help for list
+      --jq string         Filter JSON output using a jq expression
+      --json              Output JSON
+  -r, --raw               Output raw strings instead of JSON-encoded (use with --jq)
+      --space string      Space ID (defaults to configured space)
+      --template string   Format JSON output using a Go template
+```
+
+### SEE ALSO
+
+* [clickup folder](/clickup-cli/reference/clickup_folder/)	 - Manage folders
+

--- a/docs/src/content/docs/reference/clickup_folder_select.md
+++ b/docs/src/content/docs/reference/clickup_folder_select.md
@@ -1,0 +1,27 @@
+---
+title: "clickup folder select"
+description: "Auto-generated reference for clickup folder select"
+---
+
+Set default folder
+
+### Synopsis
+
+Set the default folder globally or for the current directory.
+
+```
+clickup folder select [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for select
+      --local          Set folder only for the current directory
+      --space string   Space ID (defaults to configured space)
+```
+
+### SEE ALSO
+
+* [clickup folder](/clickup-cli/reference/clickup_folder/)	 - Manage folders
+

--- a/docs/src/content/docs/reference/clickup_inbox.md
+++ b/docs/src/content/docs/reference/clickup_inbox.md
@@ -3,15 +3,24 @@ title: "clickup inbox"
 description: "Auto-generated reference for clickup inbox"
 ---
 
-Show recent @mentions
+Show recent @mentions and assignments
 
 ### Synopsis
 
-Show recent comments that @mention you across your workspace.
+Show recent comments that @mention you and tasks newly assigned to you.
 
-Scans recently updated tasks for comments containing your username.
+Combines two scans: a filtered call for tasks where you are an assignee
+(used to detect newly assigned tasks within the lookback window) and a
+workspace-wide scan for cold @mentions on tasks you are not assigned to.
+
+Results from the workspace scan are cached locally at
+~/.config/clickup/inbox_cache.json by task date_updated, so subsequent
+runs only re-fetch comments for tasks that have changed. The cache
+expires after 24 hours; pass --no-cache to force a full rescan (the cache
+is still rewritten after a --no-cache run so subsequent runs are cheap).
+
 Since ClickUp does not provide a public inbox API, this command
-approximates your inbox by searching task comments.
+approximates your inbox by combining these two endpoints.
 
 ```
 clickup inbox [flags]
@@ -20,11 +29,14 @@ clickup inbox [flags]
 ### Examples
 
 ```
-  # Show mentions from the last 7 days
+  # Show mentions and assignments from the last 7 days
   clickup inbox
 
   # Look back 30 days
   clickup inbox --days 30
+
+  # Force a full rescan, ignoring the cache
+  clickup inbox --no-cache
 
   # JSON output for scripting
   clickup inbox --json
@@ -38,6 +50,7 @@ clickup inbox [flags]
       --jq string         Filter JSON output using a jq expression
       --json              Output JSON
       --limit int         Maximum number of tasks to scan for mentions (default 200)
+      --no-cache          Bypass the local cache and re-fetch comments for every task
   -r, --raw               Output raw strings instead of JSON-encoded (use with --jq)
       --template string   Format JSON output using a Go template
 ```

--- a/docs/src/content/docs/reference/clickup_list.md
+++ b/docs/src/content/docs/reference/clickup_list.md
@@ -1,0 +1,23 @@
+---
+title: "clickup list"
+description: "Auto-generated reference for clickup list"
+---
+
+Manage lists
+
+### Synopsis
+
+List and select ClickUp lists in a folder or space.
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### SEE ALSO
+
+* [clickup](/clickup-cli/reference/clickup/)	 - ClickUp CLI - manage tasks from the command line
+* [clickup list list](/clickup-cli/reference/clickup_list_list/)	 - List ClickUp lists in a folder or space
+* [clickup list select](/clickup-cli/reference/clickup_list_select/)	 - Set default list
+

--- a/docs/src/content/docs/reference/clickup_list_list.md
+++ b/docs/src/content/docs/reference/clickup_list_list.md
@@ -1,0 +1,47 @@
+---
+title: "clickup list list"
+description: "Auto-generated reference for clickup list list"
+---
+
+List ClickUp lists in a folder or space
+
+### Synopsis
+
+List ClickUp lists. If --folder is provided, lists within that folder
+are returned. If only --space is provided, folderless lists in that space
+are returned.
+
+```
+clickup list list [flags]
+```
+
+### Examples
+
+```
+  # List lists in your default folder
+  clickup list list
+
+  # List lists in a specific folder
+  clickup list list --folder 12345
+
+  # List folderless lists in a space
+  clickup list list --space 67890
+```
+
+### Options
+
+```
+      --archived          Include archived lists
+      --folder string     Folder ID (defaults to configured folder)
+  -h, --help              help for list
+      --jq string         Filter JSON output using a jq expression
+      --json              Output JSON
+  -r, --raw               Output raw strings instead of JSON-encoded (use with --jq)
+      --space string      Space ID (defaults to configured space, used for folderless lists)
+      --template string   Format JSON output using a Go template
+```
+
+### SEE ALSO
+
+* [clickup list](/clickup-cli/reference/clickup_list/)	 - Manage lists
+

--- a/docs/src/content/docs/reference/clickup_list_select.md
+++ b/docs/src/content/docs/reference/clickup_list_select.md
@@ -1,0 +1,28 @@
+---
+title: "clickup list select"
+description: "Auto-generated reference for clickup list select"
+---
+
+Set default list
+
+### Synopsis
+
+Set the default list globally or for the current directory.
+
+```
+clickup list select [flags]
+```
+
+### Options
+
+```
+      --folder string   Folder ID (defaults to configured folder)
+  -h, --help            help for select
+      --local           Set list only for the current directory
+      --space string    Space ID (defaults to configured space, used for folderless lists)
+```
+
+### SEE ALSO
+
+* [clickup list](/clickup-cli/reference/clickup_list/)	 - Manage lists
+

--- a/docs/src/content/docs/reference/clickup_task.md
+++ b/docs/src/content/docs/reference/clickup_task.md
@@ -21,7 +21,7 @@ View, list, create, edit, and search tasks. Track time, manage dependencies and 
 * [clickup task activity](/clickup-cli/reference/clickup_task_activity/)	 - View a task's details and comment history
 * [clickup task checklist](/clickup-cli/reference/clickup_task_checklist/)	 - Manage task checklists
 * [clickup task create](/clickup-cli/reference/clickup_task_create/)	 - Create a new ClickUp task
-* [clickup task delete](/clickup-cli/reference/clickup_task_delete/)	 - Delete a task
+* [clickup task delete](/clickup-cli/reference/clickup_task_delete/)	 - Delete one or more tasks
 * [clickup task dependency](/clickup-cli/reference/clickup_task_dependency/)	 - Manage task dependencies
 * [clickup task edit](/clickup-cli/reference/clickup_task_edit/)	 - Edit a ClickUp task
 * [clickup task list](/clickup-cli/reference/clickup_task_list/)	 - List tasks in a ClickUp list

--- a/docs/src/content/docs/reference/clickup_task_checklist_item.md
+++ b/docs/src/content/docs/reference/clickup_task_checklist_item.md
@@ -19,6 +19,7 @@ Add, resolve, and remove items from a checklist.
 
 * [clickup task checklist](/clickup-cli/reference/clickup_task_checklist/)	 - Manage task checklists
 * [clickup task checklist item add](/clickup-cli/reference/clickup_task_checklist_item_add/)	 - Add an item to a checklist
+* [clickup task checklist item edit](/clickup-cli/reference/clickup_task_checklist_item_edit/)	 - Edit one or more checklist items (rename or assign)
 * [clickup task checklist item remove](/clickup-cli/reference/clickup_task_checklist_item_remove/)	 - Remove an item from a checklist
 * [clickup task checklist item resolve](/clickup-cli/reference/clickup_task_checklist_item_resolve/)	 - Mark a checklist item as resolved
 

--- a/docs/src/content/docs/reference/clickup_task_checklist_item_add.md
+++ b/docs/src/content/docs/reference/clickup_task_checklist_item_add.md
@@ -12,13 +12,18 @@ clickup task checklist item add <checklist-id> <item-name> [flags]
 ### Examples
 
 ```
+  # Add an item
   clickup task checklist item add b955c4dc-example "Run migrations"
+
+  # Add an item assigned to a user (use 'clickup member list' to find IDs)
+  clickup task checklist item add b955c4dc-example "Run migrations" --assignee 54874661
 ```
 
 ### Options
 
 ```
-  -h, --help   help for add
+      --assignee int   User ID to assign the item to (see 'clickup member list')
+  -h, --help           help for add
 ```
 
 ### SEE ALSO

--- a/docs/src/content/docs/reference/clickup_task_checklist_item_edit.md
+++ b/docs/src/content/docs/reference/clickup_task_checklist_item_edit.md
@@ -1,0 +1,39 @@
+---
+title: "clickup task checklist item edit"
+description: "Auto-generated reference for clickup task checklist item edit"
+---
+
+Edit one or more checklist items (rename or assign)
+
+```
+clickup task checklist item edit <checklist-id> <item-id> [<item-id>...] [flags]
+```
+
+### Examples
+
+```
+  # Assign a checklist item to a user
+  clickup task checklist item edit b955c4dc-example 21e08dc8-example --assignee 54874661
+
+  # Bulk assign all items in a checklist
+  clickup task checklist item edit b955c4dc-example item1 item2 item3 --assignee 54874661
+
+  # Rename a checklist item
+  clickup task checklist item edit b955c4dc-example 21e08dc8-example --name "Updated name"
+
+  # Unassign (set assignee to 0)
+  clickup task checklist item edit b955c4dc-example 21e08dc8-example --assignee 0
+```
+
+### Options
+
+```
+      --assignee int   User ID to assign the item to (0 to unassign; see 'clickup member list') (default -1)
+  -h, --help           help for edit
+      --name string    New name for the item (single item only)
+```
+
+### SEE ALSO
+
+* [clickup task checklist item](/clickup-cli/reference/clickup_task_checklist_item/)	 - Manage checklist items
+

--- a/docs/src/content/docs/reference/clickup_task_delete.md
+++ b/docs/src/content/docs/reference/clickup_task_delete.md
@@ -3,16 +3,17 @@ title: "clickup task delete"
 description: "Auto-generated reference for clickup task delete"
 ---
 
-Delete a task
+Delete one or more tasks
 
 ### Synopsis
 
-Delete a ClickUp task permanently.
+Delete one or more ClickUp tasks permanently.
 
 This action cannot be undone. A confirmation prompt is shown unless --yes is passed.
+Multiple task IDs can be provided for bulk deletion.
 
 ```
-clickup task delete <task-id> [flags]
+clickup task delete <task-id> [<task-id>...] [flags]
 ```
 
 ### Examples
@@ -23,6 +24,9 @@ clickup task delete <task-id> [flags]
 
   # Delete without confirmation
   clickup task delete CU-abc123 --yes
+
+  # Bulk delete multiple tasks
+  clickup task delete 86abc1 86abc2 86abc3 -y
 ```
 
 ### Options

--- a/docs/src/content/docs/reference/clickup_task_list.md
+++ b/docs/src/content/docs/reference/clickup_task_list.md
@@ -9,8 +9,9 @@ List tasks in a ClickUp list
 
 List tasks from a ClickUp list with optional filters.
 
-The --list-id flag is required to specify which ClickUp list to query.
-Results can be filtered by assignee, status, and sprint.
+If --list-id is not provided, the configured default list is used
+(set via 'clickup list select'). Results can be filtered by assignee,
+status, and sprint.
 
 ```
 clickup task list [flags]
@@ -19,11 +20,17 @@ clickup task list [flags]
 ### Examples
 
 ```
-  # List tasks in a ClickUp list
+  # List tasks using your configured default list
+  clickup task list
+
+  # List tasks in a specific ClickUp list
   clickup task list --list-id 12345
 
   # Filter by assignee and status
   clickup task list --list-id 12345 --assignee me --status "in progress"
+
+  # Include closed tasks
+  clickup task list --list-id 12345 --include-closed
 ```
 
 ### Options
@@ -31,9 +38,10 @@ clickup task list [flags]
 ```
       --assignee strings   Filter by assignee ID(s), or "me" for yourself
   -h, --help               help for list
+  -c, --include-closed     Include closed/completed tasks
       --jq string          Filter JSON output using a jq expression
       --json               Output JSON
-      --list-id string     ClickUp list ID (required)
+      --list-id string     ClickUp list ID (defaults to configured list)
       --page int           Page number for pagination (starts at 0)
   -r, --raw                Output raw strings instead of JSON-encoded (use with --jq)
       --sprint string      Filter by sprint name

--- a/docs/src/content/docs/reference/clickup_task_view.md
+++ b/docs/src/content/docs/reference/clickup_task_view.md
@@ -36,6 +36,9 @@ clickup task view [<task-id>...] [flags]
   # Output as JSON (includes subtasks with IDs, dates, and statuses)
   clickup task view 86a3xrwkp --json
 
+  # View with recursive subtasks (fetches all descendants)
+  clickup task view 86a3xrwkp --recursive --json
+
   # Bulk fetch multiple tasks as JSON array
   clickup task view 86abc1 86abc2 86abc3 --json
 
@@ -53,6 +56,7 @@ clickup task view [<task-id>...] [flags]
       --jq string         Filter JSON output using a jq expression
       --json              Output JSON
   -r, --raw               Output raw strings instead of JSON-encoded (use with --jq)
+      --recursive         Recursively fetch all descendant subtasks
       --template string   Format JSON output using a Go template
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 type Config struct {
 	Workspace         string                       `yaml:"workspace,omitempty"`
 	Space             string                       `yaml:"space,omitempty"`
+	Folder            string                       `yaml:"folder,omitempty"`
+	List              string                       `yaml:"list,omitempty"`
 	SprintFolder      string                       `yaml:"sprint_folder,omitempty"`
 	Editor            string                       `yaml:"editor,omitempty"`
 	Prompt            string                       `yaml:"prompt,omitempty"`
@@ -20,7 +22,9 @@ type Config struct {
 
 // DirectoryConfig holds per-directory overrides.
 type DirectoryConfig struct {
-	Space string `yaml:"space,omitempty"`
+	Space  string `yaml:"space,omitempty"`
+	Folder string `yaml:"folder,omitempty"`
+	List   string `yaml:"list,omitempty"`
 }
 
 // ConfigDir returns the path to the config directory (~/.config/clickup).
@@ -81,6 +85,26 @@ func (c *Config) SpaceForDir(dir string) string {
 		}
 	}
 	return c.Space
+}
+
+// FolderForDir returns the folder override for a specific directory, falling back to the global default.
+func (c *Config) FolderForDir(dir string) string {
+	if c.DirectoryDefaults != nil {
+		if dc, ok := c.DirectoryDefaults[dir]; ok && dc.Folder != "" {
+			return dc.Folder
+		}
+	}
+	return c.Folder
+}
+
+// ListForDir returns the list override for a specific directory, falling back to the global default.
+func (c *Config) ListForDir(dir string) string {
+	if c.DirectoryDefaults != nil {
+		if dc, ok := c.DirectoryDefaults[dir]; ok && dc.List != "" {
+			return dc.List
+		}
+	}
+	return c.List
 }
 
 // SetDirectoryDefault sets a per-directory config override.

--- a/internal/iostreams/color.go
+++ b/internal/iostreams/color.go
@@ -87,7 +87,7 @@ func (c *ColorScheme) StatusColor(status string) func(string) string {
 		return c.Gray
 	case "in progress", "in review":
 		return c.Blue
-	case "done", "complete", "closed":
+	case "done", "complete", "completed", "closed":
 		return c.Green
 	default:
 		return c.Yellow

--- a/pkg/cmd/folder/folder.go
+++ b/pkg/cmd/folder/folder.go
@@ -1,0 +1,20 @@
+package folder
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolder returns the folder parent command.
+func NewCmdFolder(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "folder",
+		Short: "Manage folders",
+		Long:  "List and select ClickUp folders in a space.",
+	}
+
+	cmd.AddCommand(NewCmdFolderList(f))
+	cmd.AddCommand(NewCmdFolderSelect(f))
+
+	return cmd
+}

--- a/pkg/cmd/folder/folder_test.go
+++ b/pkg/cmd/folder/folder_test.go
@@ -1,0 +1,69 @@
+package folder
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/triptechtravel/clickup-cli/internal/testutil"
+)
+
+var sampleFoldersJSON = `{
+	"folders": [
+		{"id": "f1", "name": "Sprint Backlog", "task_count": "5", "archived": false},
+		{"id": "f2", "name": "Product Roadmap", "task_count": "12", "archived": false}
+	]
+}`
+
+func foldersHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.Write([]byte(body))
+	}
+}
+
+func TestFolderList(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("space/67890/folder", foldersHandler(sampleFoldersJSON))
+
+	cmd := NewCmdFolderList(tf.Factory)
+	err := testutil.RunCommand(t, cmd)
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	assert.Contains(t, out, "f1")
+	assert.Contains(t, out, "Sprint Backlog")
+	assert.Contains(t, out, "f2")
+	assert.Contains(t, out, "Product Roadmap")
+}
+
+func TestFolderList_JSON(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("space/67890/folder", foldersHandler(sampleFoldersJSON))
+
+	cmd := NewCmdFolderList(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "--json")
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	var parsed []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "output should be valid JSON")
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "f1", parsed[0]["id"])
+	assert.Equal(t, "Sprint Backlog", parsed[0]["name"])
+}
+
+func TestFolderList_Empty(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("space/67890/folder", foldersHandler(`{"folders": []}`))
+
+	cmd := NewCmdFolderList(tf.Factory)
+	err := testutil.RunCommand(t, cmd)
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	assert.Contains(t, out, "No folders found.")
+}

--- a/pkg/cmd/folder/list.go
+++ b/pkg/cmd/folder/list.go
@@ -1,0 +1,97 @@
+package folder
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/apiv2"
+	"github.com/triptechtravel/clickup-cli/internal/tableprinter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolderList returns the folder list command.
+func NewCmdFolderList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		spaceID   string
+		archived  bool
+		jsonFlags cmdutil.JSONFlags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List folders in a space",
+		Long:  "List all folders in a ClickUp space.",
+		Example: `  # List folders in your default space
+  clickup folder list
+
+  # List folders in a specific space
+  clickup folder list --space 12345
+
+  # Include archived folders
+  clickup folder list --archived`,
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			if spaceID == "" {
+				dir, _ := os.Getwd()
+				spaceID = cfg.SpaceForDir(dir)
+			}
+			if spaceID == "" {
+				return fmt.Errorf("no space configured. Use --space or run 'clickup space select' first")
+			}
+
+			folders, err := apiv2.GetFoldersLocal(context.Background(), client, spaceID, archived)
+			if err != nil {
+				return fmt.Errorf("failed to fetch folders: %w", err)
+			}
+
+			if jsonFlags.WantsJSON() {
+				return jsonFlags.OutputJSON(f.IOStreams.Out, folders)
+			}
+
+			if len(folders) == 0 {
+				fmt.Fprintln(f.IOStreams.Out, "No folders found.")
+				return nil
+			}
+
+			tp := tableprinter.New(f.IOStreams)
+
+			for _, folder := range folders {
+				tp.AddField(folder.ID)
+				tp.AddField(folder.Name)
+				tp.EndRow()
+			}
+
+			if err := tp.Render(); err != nil {
+				return err
+			}
+
+			cs := f.IOStreams.ColorScheme()
+			fmt.Fprintln(f.IOStreams.Out)
+			fmt.Fprintln(f.IOStreams.Out, cs.Gray("---"))
+			fmt.Fprintln(f.IOStreams.Out, cs.Gray("Quick actions:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup folder select\n", cs.Gray("Select:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup list list --folder <id>\n", cs.Gray("Lists:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup folder list --json\n", cs.Gray("JSON:"))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space)")
+	cmd.Flags().BoolVar(&archived, "archived", false, "Include archived folders")
+	cmdutil.AddJSONFlags(cmd, &jsonFlags)
+
+	return cmd
+}

--- a/pkg/cmd/folder/select.go
+++ b/pkg/cmd/folder/select.go
@@ -1,0 +1,103 @@
+package folder
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/apiv2"
+	"github.com/triptechtravel/clickup-cli/internal/config"
+	"github.com/triptechtravel/clickup-cli/internal/prompter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdFolderSelect returns the folder select command.
+func NewCmdFolderSelect(f *cmdutil.Factory) *cobra.Command {
+	var (
+		local   bool
+		spaceID string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Set default folder",
+		Long:  "Set the default folder globally or for the current directory.",
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			if spaceID == "" {
+				dir, _ := os.Getwd()
+				spaceID = cfg.SpaceForDir(dir)
+			}
+			if spaceID == "" {
+				return fmt.Errorf("no space configured. Use --space or run 'clickup space select' first")
+			}
+
+			folders, err := apiv2.GetFoldersLocal(context.Background(), client, spaceID, false)
+			if err != nil {
+				return fmt.Errorf("failed to fetch folders: %w", err)
+			}
+
+			if len(folders) == 0 {
+				return fmt.Errorf("no folders found in space %s", spaceID)
+			}
+
+			p := prompter.New(f.IOStreams)
+			names := make([]string, len(folders))
+			for i, folder := range folders {
+				names[i] = fmt.Sprintf("%s (%s)", folder.Name, folder.ID)
+			}
+
+			idx, err := p.Select("Select a folder:", names)
+			if err != nil {
+				return err
+			}
+
+			selectedID := folders[idx].ID
+			selectedName := folders[idx].Name
+
+			if local {
+				dir, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				dc := config.DirectoryConfig{Folder: selectedID}
+				// Preserve existing directory defaults.
+				if cfg.DirectoryDefaults != nil {
+					if existing, ok := cfg.DirectoryDefaults[dir]; ok {
+						dc.Space = existing.Space
+						dc.List = existing.List
+					}
+				}
+				cfg.SetDirectoryDefault(dir, dc)
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Default folder for %s set to %s (%s)\n", dir, selectedName, selectedID)
+			} else {
+				cfg.Folder = selectedID
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Default folder set to %s (%s)\n", selectedName, selectedID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&local, "local", false, "Set folder only for the current directory")
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space)")
+
+	return cmd
+}

--- a/pkg/cmd/list/list.go
+++ b/pkg/cmd/list/list.go
@@ -1,0 +1,20 @@
+package list
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdList returns the list parent command.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "Manage lists",
+		Long:  "List and select ClickUp lists in a folder or space.",
+	}
+
+	cmd.AddCommand(NewCmdListList(f))
+	cmd.AddCommand(NewCmdListSelect(f))
+
+	return cmd
+}

--- a/pkg/cmd/list/list_list.go
+++ b/pkg/cmd/list/list_list.go
@@ -1,0 +1,115 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/apiv2"
+	"github.com/triptechtravel/clickup-cli/internal/clickup"
+	"github.com/triptechtravel/clickup-cli/internal/tableprinter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdListList returns the list list command.
+func NewCmdListList(f *cmdutil.Factory) *cobra.Command {
+	var (
+		folderID  string
+		spaceID   string
+		archived  bool
+		jsonFlags cmdutil.JSONFlags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List ClickUp lists in a folder or space",
+		Long: `List ClickUp lists. If --folder is provided, lists within that folder
+are returned. If only --space is provided, folderless lists in that space
+are returned.`,
+		Example: `  # List lists in your default folder
+  clickup list list
+
+  # List lists in a specific folder
+  clickup list list --folder 12345
+
+  # List folderless lists in a space
+  clickup list list --space 67890`,
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			dir, _ := os.Getwd()
+
+			if folderID == "" {
+				folderID = cfg.FolderForDir(dir)
+			}
+			if spaceID == "" {
+				spaceID = cfg.SpaceForDir(dir)
+			}
+
+			var lists []clickup.List
+			ctx := context.Background()
+
+			if folderID != "" {
+				lists, err = apiv2.GetListsLocal(ctx, client, folderID, archived)
+				if err != nil {
+					return fmt.Errorf("failed to fetch lists: %w", err)
+				}
+			} else if spaceID != "" {
+				lists, err = apiv2.GetFolderlessListsLocal(ctx, client, spaceID, archived)
+				if err != nil {
+					return fmt.Errorf("failed to fetch folderless lists: %w", err)
+				}
+			} else {
+				return fmt.Errorf("no folder or space configured. Use --folder, --space, or run 'clickup folder select' / 'clickup space select' first")
+			}
+
+			if jsonFlags.WantsJSON() {
+				return jsonFlags.OutputJSON(f.IOStreams.Out, lists)
+			}
+
+			if len(lists) == 0 {
+				fmt.Fprintln(f.IOStreams.Out, "No lists found.")
+				return nil
+			}
+
+			tp := tableprinter.New(f.IOStreams)
+
+			for _, l := range lists {
+				tp.AddField(l.ID)
+				tp.AddField(l.Name)
+				tp.EndRow()
+			}
+
+			if err := tp.Render(); err != nil {
+				return err
+			}
+
+			cs := f.IOStreams.ColorScheme()
+			fmt.Fprintln(f.IOStreams.Out)
+			fmt.Fprintln(f.IOStreams.Out, cs.Gray("---"))
+			fmt.Fprintln(f.IOStreams.Out, cs.Gray("Quick actions:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup list select\n", cs.Gray("Select:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup task list --list-id <id>\n", cs.Gray("Tasks:"))
+			fmt.Fprintf(f.IOStreams.Out, "  %s  clickup list list --json\n", cs.Gray("JSON:"))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&folderID, "folder", "", "Folder ID (defaults to configured folder)")
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space, used for folderless lists)")
+	cmd.Flags().BoolVar(&archived, "archived", false, "Include archived lists")
+	cmdutil.AddJSONFlags(cmd, &jsonFlags)
+
+	return cmd
+}

--- a/pkg/cmd/list/list_test.go
+++ b/pkg/cmd/list/list_test.go
@@ -1,0 +1,77 @@
+package list
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/triptechtravel/clickup-cli/internal/config"
+	"github.com/triptechtravel/clickup-cli/internal/testutil"
+)
+
+var sampleListsJSON = `{
+	"lists": [
+		{"id": "l1", "name": "To Do", "task_count": "3"},
+		{"id": "l2", "name": "In Progress", "task_count": "7"}
+	]
+}`
+
+func listsHandler(body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.Write([]byte(body))
+	}
+}
+
+func TestListList_WithFolder(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("folder/f1/list", listsHandler(sampleListsJSON))
+
+	cmd := NewCmdListList(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "--folder", "f1")
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	assert.Contains(t, out, "l1")
+	assert.Contains(t, out, "To Do")
+	assert.Contains(t, out, "l2")
+	assert.Contains(t, out, "In Progress")
+}
+
+func TestListList_WithSpace(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("space/67890/list", listsHandler(sampleListsJSON))
+
+	// Clear folder so it falls through to space (folderless)
+	tf.Factory.SetConfig(&config.Config{
+		Workspace: "12345",
+		Space:     "67890",
+	})
+
+	cmd := NewCmdListList(tf.Factory)
+	err := testutil.RunCommand(t, cmd)
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	assert.Contains(t, out, "l1")
+	assert.Contains(t, out, "To Do")
+}
+
+func TestListList_JSON(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+	tf.HandleFunc("folder/f1/list", listsHandler(sampleListsJSON))
+
+	cmd := NewCmdListList(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "--folder", "f1", "--json")
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	var parsed []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed), "output should be valid JSON")
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "l1", parsed[0]["id"])
+	assert.Equal(t, "To Do", parsed[0]["name"])
+}

--- a/pkg/cmd/list/select.go
+++ b/pkg/cmd/list/select.go
@@ -1,0 +1,119 @@
+package list
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/triptechtravel/clickup-cli/internal/apiv2"
+	"github.com/triptechtravel/clickup-cli/internal/clickup"
+	"github.com/triptechtravel/clickup-cli/internal/config"
+	"github.com/triptechtravel/clickup-cli/internal/prompter"
+	"github.com/triptechtravel/clickup-cli/pkg/cmdutil"
+)
+
+// NewCmdListSelect returns the list select command.
+func NewCmdListSelect(f *cmdutil.Factory) *cobra.Command {
+	var (
+		local    bool
+		folderID string
+		spaceID  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Set default list",
+		Long:  "Set the default list globally or for the current directory.",
+		PreRunE: cmdutil.NeedsAuth(f),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			dir, _ := os.Getwd()
+
+			if folderID == "" {
+				folderID = cfg.FolderForDir(dir)
+			}
+			if spaceID == "" {
+				spaceID = cfg.SpaceForDir(dir)
+			}
+
+			var lists []clickup.List
+			ctx := context.Background()
+
+			if folderID != "" {
+				lists, err = apiv2.GetListsLocal(ctx, client, folderID, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch lists: %w", err)
+				}
+			} else if spaceID != "" {
+				lists, err = apiv2.GetFolderlessListsLocal(ctx, client, spaceID, false)
+				if err != nil {
+					return fmt.Errorf("failed to fetch folderless lists: %w", err)
+				}
+			} else {
+				return fmt.Errorf("no folder or space configured. Use --folder, --space, or run 'clickup folder select' / 'clickup space select' first")
+			}
+
+			if len(lists) == 0 {
+				return fmt.Errorf("no lists found")
+			}
+
+			p := prompter.New(f.IOStreams)
+			names := make([]string, len(lists))
+			for i, l := range lists {
+				names[i] = fmt.Sprintf("%s (%s)", l.Name, l.ID)
+			}
+
+			idx, err := p.Select("Select a list:", names)
+			if err != nil {
+				return err
+			}
+
+			selectedID := lists[idx].ID
+			selectedName := lists[idx].Name
+
+			if local {
+				dir, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				dc := config.DirectoryConfig{List: selectedID}
+				// Preserve existing directory defaults.
+				if cfg.DirectoryDefaults != nil {
+					if existing, ok := cfg.DirectoryDefaults[dir]; ok {
+						dc.Space = existing.Space
+						dc.Folder = existing.Folder
+					}
+				}
+				cfg.SetDirectoryDefault(dir, dc)
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Default list for %s set to %s (%s)\n", dir, selectedName, selectedID)
+			} else {
+				cfg.List = selectedID
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+				fmt.Fprintf(f.IOStreams.Out, "Default list set to %s (%s)\n", selectedName, selectedID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&local, "local", false, "Set list only for the current directory")
+	cmd.Flags().StringVar(&folderID, "folder", "", "Folder ID (defaults to configured folder)")
+	cmd.Flags().StringVar(&spaceID, "space", "", "Space ID (defaults to configured space, used for folderless lists)")
+
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -8,8 +8,10 @@ import (
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/completion"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/doc"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/field"
+	"github.com/triptechtravel/clickup-cli/pkg/cmd/folder"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/inbox"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/link"
+	listcmd "github.com/triptechtravel/clickup-cli/pkg/cmd/list"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/member"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/space"
 	"github.com/triptechtravel/clickup-cli/pkg/cmd/sprint"
@@ -48,6 +50,8 @@ Links GitHub PRs, branches, and commits to ClickUp tasks.`,
 	cmd.AddCommand(sprint.NewCmdSprint(f))
 	cmd.AddCommand(space.NewCmdSpace(f))
 	cmd.AddCommand(field.NewCmdField(f))
+	cmd.AddCommand(folder.NewCmdFolder(f))
+	cmd.AddCommand(listcmd.NewCmdList(f))
 	cmd.AddCommand(tag.NewCmdTag(f))
 
 	// Workspace

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,12 +15,13 @@ import (
 )
 
 type listOptions struct {
-	listID    string
-	assignee  []string
-	status    []string
-	sprint    string
-	page      int
-	jsonFlags cmdutil.JSONFlags
+	listID        string
+	assignee      []string
+	status        []string
+	sprint        string
+	page          int
+	includeClosed bool
+	jsonFlags     cmdutil.JSONFlags
 }
 
 // NewCmdList returns a command to list ClickUp tasks in a given list.
@@ -31,29 +33,43 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		Short: "List tasks in a ClickUp list",
 		Long: `List tasks from a ClickUp list with optional filters.
 
-The --list-id flag is required to specify which ClickUp list to query.
-Results can be filtered by assignee, status, and sprint.`,
-		Example: `  # List tasks in a ClickUp list
+If --list-id is not provided, the configured default list is used
+(set via 'clickup list select'). Results can be filtered by assignee,
+status, and sprint.`,
+		Example: `  # List tasks using your configured default list
+  clickup task list
+
+  # List tasks in a specific ClickUp list
   clickup task list --list-id 12345
 
   # Filter by assignee and status
-  clickup task list --list-id 12345 --assignee me --status "in progress"`,
+  clickup task list --list-id 12345 --assignee me --status "in progress"
+
+  # Include closed tasks
+  clickup task list --list-id 12345 --include-closed`,
 		PersistentPreRunE: cmdutil.NeedsAuth(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.listID == "" {
-				return fmt.Errorf("required flag --list-id not set")
+				cfg, err := f.Config()
+				if err != nil {
+					return err
+				}
+				dir, _ := os.Getwd()
+				opts.listID = cfg.ListForDir(dir)
+			}
+			if opts.listID == "" {
+				return fmt.Errorf("no list specified. Use --list-id or run 'clickup list select' to set a default")
 			}
 			return runList(f, opts)
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.listID, "list-id", "", "ClickUp list ID (required)")
+	cmd.Flags().StringVar(&opts.listID, "list-id", "", "ClickUp list ID (defaults to configured list)")
 	cmd.Flags().StringSliceVar(&opts.assignee, "assignee", nil, `Filter by assignee ID(s), or "me" for yourself`)
 	cmd.Flags().StringSliceVar(&opts.status, "status", nil, "Filter by status(es)")
 	cmd.Flags().StringVar(&opts.sprint, "sprint", "", "Filter by sprint name")
 	cmd.Flags().IntVar(&opts.page, "page", 0, "Page number for pagination (starts at 0)")
-
-	_ = cmd.MarkFlagRequired("list-id")
+	cmd.Flags().BoolVarP(&opts.includeClosed, "include-closed", "c", false, "Include closed/completed tasks")
 
 	cmdutil.AddJSONFlags(cmd, &opts.jsonFlags)
 
@@ -80,6 +96,9 @@ func runList(f *cmdutil.Factory, opts *listOptions) error {
 	}
 	if opts.sprint != "" {
 		q.Add("tags[]", opts.sprint)
+	}
+	if opts.includeClosed {
+		q.Set("include_closed", "true")
 	}
 
 	qs := ""

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -1,0 +1,83 @@
+package task
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/triptechtravel/clickup-cli/internal/config"
+	"github.com/triptechtravel/clickup-cli/internal/testutil"
+)
+
+var sampleTasksJSON = `{
+	"tasks": [
+		{
+			"id": "t1",
+			"name": "Fix bug",
+			"status": {"status": "open", "color": "#999"},
+			"priority": {"priority": "high", "color": "#f00"},
+			"assignees": [],
+			"tags": []
+		}
+	]
+}`
+
+func TestTaskList_FallsBackToConfiguredList(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+
+	tf.Factory.SetConfig(&config.Config{
+		Workspace: "12345",
+		Space:     "67890",
+		List:      "configured-list",
+	})
+
+	tf.HandleFunc("list/configured-list/task", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.Write([]byte(sampleTasksJSON))
+	})
+
+	cmd := NewCmdList(tf.Factory)
+	err := testutil.RunCommand(t, cmd)
+	require.NoError(t, err)
+
+	out := tf.OutBuf.String()
+	assert.Contains(t, out, "t1")
+	assert.Contains(t, out, "Fix bug")
+}
+
+func TestTaskList_IncludeClosed(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+
+	var capturedQuery string
+	tf.HandleFunc("list/mylist/task", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.Write([]byte(sampleTasksJSON))
+	})
+
+	cmd := NewCmdList(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "--list-id", "mylist", "--include-closed")
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(capturedQuery, "include_closed=true"),
+		"expected include_closed=true in query, got: %s", capturedQuery)
+}
+
+func TestTaskList_NoListError(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+
+	tf.Factory.SetConfig(&config.Config{
+		Workspace: "12345",
+		Space:     "67890",
+		// No List configured
+	})
+
+	cmd := NewCmdList(tf.Factory)
+	err := testutil.RunCommand(t, cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no list specified")
+}


### PR DESCRIPTION
## Summary

- Add `clickup folder list` and `clickup folder select` commands for discovering folders in a space
- Add `clickup list list` and `clickup list select` commands for discovering lists in folders or spaces
- Make `task list --list-id` optional — falls back to configured list via `list select` (global or per-directory)
- Add `--include-closed` / `-c` flag to `task list`
- Add per-directory config overrides for folder and list
- Add "completed" to green status colors

Closes #12. Supersedes #13 — rebuilt from scratch on the apiv2 architecture (go-clickup dependency removed in v0.29.0).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 20 test packages pass (9 new tests for folder/list/task commands)
- [x] Smoke tested `folder list --json` and `list list --folder` against real ClickUp API
- [x] Docs regenerated via `go run ./cmd/gen-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)