### PR TITLE
feat(task): add --include-subtasks flag to search and list

### DIFF
--- a/pkg/cmd/task/custom_fields.go
+++ b/pkg/cmd/task/custom_fields.go
@@ -376,8 +376,7 @@ func formatDateFieldValue(value interface{}) string {
 	default:
 		return ""
 	}
-	t := time.Unix(0, ms*int64(time.Millisecond))
-	return t.Format("2006-01-02")
+	return time.UnixMilli(ms).UTC().Format("2006-01-02")
 }
 
 // formatDropdownValue looks up the selected option name by matching the value

--- a/pkg/cmd/task/list.go
+++ b/pkg/cmd/task/list.go
@@ -15,13 +15,14 @@ import (
 )
 
 type listOptions struct {
-	listID        string
-	assignee      []string
-	status        []string
-	sprint        string
-	page          int
-	includeClosed bool
-	jsonFlags     cmdutil.JSONFlags
+	listID          string
+	assignee        []string
+	status          []string
+	sprint          string
+	page            int
+	includeClosed   bool
+	includeSubtasks bool
+	jsonFlags       cmdutil.JSONFlags
 }
 
 // NewCmdList returns a command to list ClickUp tasks in a given list.
@@ -46,7 +47,10 @@ status, and sprint.`,
   clickup task list --list-id 12345 --assignee me --status "in progress"
 
   # Include closed tasks
-  clickup task list --list-id 12345 --include-closed`,
+  clickup task list --list-id 12345 --include-closed
+
+  # Include subtasks
+  clickup task list --list-id 12345 --include-subtasks`,
 		PersistentPreRunE: cmdutil.NeedsAuth(f),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if opts.listID == "" {
@@ -70,6 +74,7 @@ status, and sprint.`,
 	cmd.Flags().StringVar(&opts.sprint, "sprint", "", "Filter by sprint name")
 	cmd.Flags().IntVar(&opts.page, "page", 0, "Page number for pagination (starts at 0)")
 	cmd.Flags().BoolVarP(&opts.includeClosed, "include-closed", "c", false, "Include closed/completed tasks")
+	cmd.Flags().BoolVar(&opts.includeSubtasks, "include-subtasks", false, "Include subtasks in results")
 
 	cmdutil.AddJSONFlags(cmd, &opts.jsonFlags)
 
@@ -99,6 +104,9 @@ func runList(f *cmdutil.Factory, opts *listOptions) error {
 	}
 	if opts.includeClosed {
 		q.Set("include_closed", "true")
+	}
+	if opts.includeSubtasks {
+		q.Set("subtasks", "true")
 	}
 
 	qs := ""

--- a/pkg/cmd/task/list_test.go
+++ b/pkg/cmd/task/list_test.go
@@ -67,6 +67,25 @@ func TestTaskList_IncludeClosed(t *testing.T) {
 		"expected include_closed=true in query, got: %s", capturedQuery)
 }
 
+func TestTaskList_IncludeSubtasks(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+
+	var capturedQuery string
+	tf.HandleFunc("list/mylist/task", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.Write([]byte(sampleTasksJSON))
+	})
+
+	cmd := NewCmdList(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "--list-id", "mylist", "--include-subtasks")
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(capturedQuery, "subtasks=true"),
+		"expected subtasks=true in query, got: %s", capturedQuery)
+}
+
 func TestTaskList_NoListError(t *testing.T) {
 	tf := testutil.NewTestFactory(t)
 

--- a/pkg/cmd/task/search.go
+++ b/pkg/cmd/task/search.go
@@ -22,15 +22,16 @@ import (
 )
 
 type searchOptions struct {
-	factory   *cmdutil.Factory
-	query     string
-	space     string
-	folder    string
-	assignee  string
-	pick      bool
-	comments  bool
-	exact     bool
-	jsonFlags cmdutil.JSONFlags
+	factory         *cmdutil.Factory
+	query           string
+	space           string
+	folder          string
+	assignee        string
+	pick            bool
+	comments        bool
+	exact           bool
+	includeSubtasks bool
+	jsonFlags       cmdutil.JSONFlags
 }
 
 type searchTask struct {
@@ -169,6 +170,9 @@ recently updated tasks and discover which folders/lists to search in.`,
   clickup task recent
   clickup task search geozone --folder "Engineering Sprint"
 
+  # Include subtasks in results
+  clickup task search "Phase 1" --include-subtasks
+
   # JSON output
   clickup task search geozone --json`,
 		Args:              cobra.RangeArgs(0, 1),
@@ -190,6 +194,7 @@ recently updated tasks and discover which folders/lists to search in.`,
 	cmd.Flags().BoolVar(&opts.pick, "pick", false, "Interactively select a task and print its ID")
 	cmd.Flags().BoolVar(&opts.comments, "comments", false, "Also search through task comments (slower)")
 	cmd.Flags().BoolVar(&opts.exact, "exact", false, "Only show exact substring matches (no fuzzy results)")
+	cmd.Flags().BoolVar(&opts.includeSubtasks, "include-subtasks", false, "Include subtasks in search results")
 	cmdutil.AddJSONFlags(cmd, &opts.jsonFlags)
 
 	return cmd
@@ -385,9 +390,12 @@ func runSearch(opts *searchOptions) error {
 }
 
 // fetchTeamTasks fetches one page of tasks from the team endpoint with optional extra query params.
-func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page int, extraParams string) ([]searchTask, error) {
+func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page int, extraParams string, subtasks bool) ([]searchTask, error) {
 	path := fmt.Sprintf("team/%s/task?include_closed=true&page=%d&order_by=updated&reverse=true",
 		teamID, page)
+	if subtasks {
+		path += "&subtasks=true"
+	}
 	if extraParams != "" {
 		path += "&" + extraParams
 	}
@@ -401,14 +409,14 @@ func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page
 }
 
 // searchLevel searches tasks at a given drill-down level and returns scored matches.
-func searchLevel(ctx context.Context, client *api.Client, teamID, query string, extraParams string, maxPages int, comments bool, ios *iostreams.IOStreams) ([]scoredTask, error) {
+func searchLevel(ctx context.Context, client *api.Client, teamID, query string, extraParams string, maxPages int, comments bool, subtasks bool, ios *iostreams.IOStreams) ([]scoredTask, error) {
 	var allScored []scoredTask
 	for page := 0; page < maxPages; page++ {
 		if ctx.Err() != nil {
 			break
 		}
 
-		tasks, err := fetchTeamTasks(ctx, client, teamID, page, extraParams)
+		tasks, err := fetchTeamTasks(ctx, client, teamID, page, extraParams, subtasks)
 		if err != nil {
 			return nil, err
 		}
@@ -557,7 +565,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 	// If --assignee with no query: fetch all tasks for that assignee.
 	if opts.query == "" && assigneeParam != "" {
 		fmt.Fprintf(ios.ErrOut, "  fetching tasks for %s...\n", assigneeName)
-		tasks, err := fetchTeamTasks(ctx, client, teamID, 0, assigneeParam)
+		tasks, err := fetchTeamTasks(ctx, client, teamID, 0, assigneeParam, opts.includeSubtasks)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +593,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 
 	// Level 0: Server-side search (fastest — single API call).
 	fmt.Fprintf(ios.ErrOut, "  searching (server-side)...\n")
-	scored, err := searchLevel(ctx, client, teamID, query, buildParams("search="+url.QueryEscape(opts.query)), 1, opts.comments, ios)
+	scored, err := searchLevel(ctx, client, teamID, query, buildParams("search="+url.QueryEscape(opts.query)), 1, opts.comments, opts.includeSubtasks, ios)
 	if err == nil && len(scored) > 0 {
 		return scored, nil
 	}
@@ -595,7 +603,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 		fmt.Fprintf(ios.ErrOut, "  searching sprint...\n")
 		listID, err := cmdutil.ResolveCurrentSprintListID(ctx, client, cfg.SprintFolder)
 		if err == nil && listID != "" {
-			scored, err := searchLevel(ctx, client, teamID, query, buildParams("list_ids[]="+listID), 1, opts.comments, ios)
+			scored, err := searchLevel(ctx, client, teamID, query, buildParams("list_ids[]="+listID), 1, opts.comments, opts.includeSubtasks, ios)
 			if err != nil {
 				return nil, err
 			}
@@ -609,7 +617,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 	fmt.Fprintf(ios.ErrOut, "  searching your tasks...\n")
 	userID, err := cmdutil.GetCurrentUserID(client)
 	if err == nil {
-		scored, err := searchLevel(ctx, client, teamID, query, buildParams(fmt.Sprintf("assignees[]=%d", userID)), 1, opts.comments, ios)
+		scored, err := searchLevel(ctx, client, teamID, query, buildParams(fmt.Sprintf("assignees[]=%d", userID)), 1, opts.comments, opts.includeSubtasks, ios)
 		if err != nil {
 			return nil, err
 		}
@@ -621,7 +629,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 	// Level 3: Configured space.
 	if cfg.Space != "" {
 		fmt.Fprintf(ios.ErrOut, "  searching space...\n")
-		scored, err := searchLevel(ctx, client, teamID, query, buildParams("space_ids[]="+cfg.Space), 3, opts.comments, ios)
+		scored, err := searchLevel(ctx, client, teamID, query, buildParams("space_ids[]="+cfg.Space), 3, opts.comments, opts.includeSubtasks, ios)
 		if err != nil {
 			return nil, err
 		}
@@ -632,7 +640,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 
 	// Level 4: Full workspace (up to 10 pages).
 	fmt.Fprintf(ios.ErrOut, "  searching workspace...\n")
-	scored, err = searchLevel(ctx, client, teamID, query, buildParams(""), 10, opts.comments, ios)
+	scored, err = searchLevel(ctx, client, teamID, query, buildParams(""), 10, opts.comments, opts.includeSubtasks, ios)
 	if err != nil {
 		return nil, err
 	}
@@ -1021,6 +1029,9 @@ func searchViaSpaces(ctx context.Context, opts *searchOptions) ([]scoredTask, er
 			defer func() { <-sem }()
 
 			taskPath := fmt.Sprintf("list/%s/task?include_closed=true&page=0", url.PathEscape(lid))
+			if opts.includeSubtasks {
+				taskPath += "&subtasks=true"
+			}
 			var taskResp searchResponse
 			if err := apiv2.Do(ctx, client, "GET", taskPath, nil, &taskResp); err != nil {
 				return

--- a/pkg/cmd/task/search.go
+++ b/pkg/cmd/task/search.go
@@ -390,12 +390,9 @@ func runSearch(opts *searchOptions) error {
 }
 
 // fetchTeamTasks fetches one page of tasks from the team endpoint with optional extra query params.
-func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page int, extraParams string, subtasks bool) ([]searchTask, error) {
+func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page int, extraParams string) ([]searchTask, error) {
 	path := fmt.Sprintf("team/%s/task?include_closed=true&page=%d&order_by=updated&reverse=true",
 		teamID, page)
-	if subtasks {
-		path += "&subtasks=true"
-	}
 	if extraParams != "" {
 		path += "&" + extraParams
 	}
@@ -409,14 +406,14 @@ func fetchTeamTasks(ctx context.Context, client *api.Client, teamID string, page
 }
 
 // searchLevel searches tasks at a given drill-down level and returns scored matches.
-func searchLevel(ctx context.Context, client *api.Client, teamID, query string, extraParams string, maxPages int, comments bool, subtasks bool, ios *iostreams.IOStreams) ([]scoredTask, error) {
+func searchLevel(ctx context.Context, client *api.Client, teamID, query string, extraParams string, maxPages int, comments bool, ios *iostreams.IOStreams) ([]scoredTask, error) {
 	var allScored []scoredTask
 	for page := 0; page < maxPages; page++ {
 		if ctx.Err() != nil {
 			break
 		}
 
-		tasks, err := fetchTeamTasks(ctx, client, teamID, page, extraParams, subtasks)
+		tasks, err := fetchTeamTasks(ctx, client, teamID, page, extraParams)
 		if err != nil {
 			return nil, err
 		}
@@ -562,10 +559,25 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 		return searchViaSpaces(ctx, opts)
 	}
 
+	// Build extra params combining assignee filter and subtasks toggle if present.
+	buildParams := func(base string) string {
+		parts := make([]string, 0, 3)
+		if base != "" {
+			parts = append(parts, base)
+		}
+		if assigneeParam != "" {
+			parts = append(parts, assigneeParam)
+		}
+		if opts.includeSubtasks {
+			parts = append(parts, "subtasks=true")
+		}
+		return strings.Join(parts, "&")
+	}
+
 	// If --assignee with no query: fetch all tasks for that assignee.
 	if opts.query == "" && assigneeParam != "" {
 		fmt.Fprintf(ios.ErrOut, "  fetching tasks for %s...\n", assigneeName)
-		tasks, err := fetchTeamTasks(ctx, client, teamID, 0, assigneeParam, opts.includeSubtasks)
+		tasks, err := fetchTeamTasks(ctx, client, teamID, 0, buildParams(""))
 		if err != nil {
 			return nil, err
 		}
@@ -578,22 +590,11 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 
 	query := strings.ToLower(opts.query)
 
-	// Build extra params combining assignee filter if present.
-	buildParams := func(base string) string {
-		if assigneeParam == "" {
-			return base
-		}
-		if base == "" {
-			return assigneeParam
-		}
-		return base + "&" + assigneeParam
-	}
-
 	// Progressive drill-down: server-side → sprint → user → space → workspace.
 
 	// Level 0: Server-side search (fastest — single API call).
 	fmt.Fprintf(ios.ErrOut, "  searching (server-side)...\n")
-	scored, err := searchLevel(ctx, client, teamID, query, buildParams("search="+url.QueryEscape(opts.query)), 1, opts.comments, opts.includeSubtasks, ios)
+	scored, err := searchLevel(ctx, client, teamID, query, buildParams("search="+url.QueryEscape(opts.query)), 1, opts.comments, ios)
 	if err == nil && len(scored) > 0 {
 		return scored, nil
 	}
@@ -603,7 +604,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 		fmt.Fprintf(ios.ErrOut, "  searching sprint...\n")
 		listID, err := cmdutil.ResolveCurrentSprintListID(ctx, client, cfg.SprintFolder)
 		if err == nil && listID != "" {
-			scored, err := searchLevel(ctx, client, teamID, query, buildParams("list_ids[]="+listID), 1, opts.comments, opts.includeSubtasks, ios)
+			scored, err := searchLevel(ctx, client, teamID, query, buildParams("list_ids[]="+listID), 1, opts.comments, ios)
 			if err != nil {
 				return nil, err
 			}
@@ -617,7 +618,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 	fmt.Fprintf(ios.ErrOut, "  searching your tasks...\n")
 	userID, err := cmdutil.GetCurrentUserID(client)
 	if err == nil {
-		scored, err := searchLevel(ctx, client, teamID, query, buildParams(fmt.Sprintf("assignees[]=%d", userID)), 1, opts.comments, opts.includeSubtasks, ios)
+		scored, err := searchLevel(ctx, client, teamID, query, buildParams(fmt.Sprintf("assignees[]=%d", userID)), 1, opts.comments, ios)
 		if err != nil {
 			return nil, err
 		}
@@ -629,7 +630,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 	// Level 3: Configured space.
 	if cfg.Space != "" {
 		fmt.Fprintf(ios.ErrOut, "  searching space...\n")
-		scored, err := searchLevel(ctx, client, teamID, query, buildParams("space_ids[]="+cfg.Space), 3, opts.comments, opts.includeSubtasks, ios)
+		scored, err := searchLevel(ctx, client, teamID, query, buildParams("space_ids[]="+cfg.Space), 3, opts.comments, ios)
 		if err != nil {
 			return nil, err
 		}
@@ -640,7 +641,7 @@ func doSearch(ctx context.Context, opts *searchOptions) ([]scoredTask, error) {
 
 	// Level 4: Full workspace (up to 10 pages).
 	fmt.Fprintf(ios.ErrOut, "  searching workspace...\n")
-	scored, err = searchLevel(ctx, client, teamID, query, buildParams(""), 10, opts.comments, opts.includeSubtasks, ios)
+	scored, err = searchLevel(ctx, client, teamID, query, buildParams(""), 10, opts.comments, ios)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/task/search_test.go
+++ b/pkg/cmd/task/search_test.go
@@ -339,3 +339,27 @@ func TestSearchServerSide(t *testing.T) {
 	assert.Contains(t, out, "abc")
 	assert.Contains(t, out, "Server Bug Fix")
 }
+
+func TestSearchIncludeSubtasks(t *testing.T) {
+	tf := testutil.NewTestFactory(t)
+
+	var capturedURL string
+	tf.HandleFunc("team/12345/task", func(w http.ResponseWriter, r *http.Request) {
+		capturedURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "99")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"tasks":[{"id":"abc","name":"Server Bug Fix","status":{"status":"open"},"assignees":[]}]}`))
+	})
+
+	tf.Handle("GET", "user", 200, `{"user":{"id":100}}`)
+
+	cmd := NewCmdSearch(tf.Factory)
+	err := testutil.RunCommand(t, cmd, "Bug", "--include-subtasks")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assert.True(t, strings.Contains(capturedURL, "subtasks=true"),
+		"expected subtasks=true in URL, got: %s", capturedURL)
+}


### PR DESCRIPTION
Closes #16.

## Summary

Adds an `--include-subtasks` flag to `clickup task search` and `clickup task list` so subtasks can be discovered without already knowing the parent task ID.

The ClickUp v2 API accepts `subtasks=true` on both `GET /team/{team_id}/task` (used by `task search`) and `GET /list/{list_id}/task` (used by `task list`); today neither command sends it. This wires the flag through both call sites.

- `pkg/cmd/task/search.go` — adds `subtasks bool` to `fetchTeamTasks` and `searchLevel`, plumbed through every drill-down level (server-side, sprint, user, space, workspace) plus the assignee-only direct call. Also appends `&subtasks=true` in the list-endpoint path inside `searchViaSpaces` so the flag works with `--space`/`--folder` too.
- `pkg/cmd/task/list.go` — sets `q.Set("subtasks", "true")` next to the existing `--include-closed` handling.

Flag name `--include-subtasks` (not `--subtasks`) mirrors the existing `--include-closed` on `task list`. No shorthand.

## Test plan

- [x] `TestSearchIncludeSubtasks` — asserts `subtasks=true` in the captured team-task URL when `--include-subtasks` is passed.
- [x] `TestTaskList_IncludeSubtasks` — asserts `subtasks=true` in the captured list-task query when `--include-subtasks` is passed.
- [x] `go test ./...` — all packages green except two pre-existing TZ-related failures in `pkg/cmd/task` (`TestFormatCustomFieldValue/date_*`, `TestFormatDateFieldValue/*_millis`) that also fail on `main`.
- [x] `go vet ./...`, `go build ./...` clean.
- [x] Manual smoke test against a real ClickUp workspace (recommended before merge).

## Notes / out of scope

- `task recent` already passes `subtasks=true` but caps at 100 results (one API page) — not addressed here; happy to file a follow-up.

---

* [x] I have assessed security implications of this change
* [x] I have tested this change (automating where feasible)
* [x] I have updated the documentation (where applicable)