### PR TITLE
fix(build): auto-run api-gen when generated files are missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,18 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/build.Commit=$(COMMIT) \
 	-X $(MODULE)/internal/build.Date=$(DATE)
 
-.PHONY: build install test lint clean smoke
+.PHONY: build install test lint clean smoke ensure-gen
 
-build:
+ensure-gen:
 	@[ -f api/clickupv3/client.gen.go ] || $(MAKE) api-gen
+
+build: ensure-gen
 	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) ./cmd/clickup
 
-install:
+install: ensure-gen
 	go install -ldflags "$(LDFLAGS)" ./cmd/clickup
 
-test:
+test: ensure-gen
 	go test ./...
 
 # Round-trip the typed-wrapper code paths against a real ClickUp workspace.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LDFLAGS := -s -w \
 .PHONY: build install test lint clean smoke
 
 build:
+	@[ -f api/clickupv3/client.gen.go ] || $(MAKE) api-gen
 	go build -ldflags "$(LDFLAGS)" -o bin/$(BINARY) ./cmd/clickup
 
 install:


### PR DESCRIPTION
## Problem

`go build` fails after a plain `git clone` because the generated API files (`api/clickupv{2,3}/*.gen.go`, `internal/apiv{2,3}/operations.gen.go`) are gitignored. This produces 14 compile errors for types that only exist in the generated code:

```
internal/apiv3/chat.go: undefined: GetChatChannelsParams
pkg/cmdutil/status.go: undefined: apiv2.GetSpace
... (14 total)
```

Any Dockerfile or CI pipeline that does `git clone && go build` is broken.

## Fix

One line added to the `build` target — if the generated files are absent, run `make api-gen` first:

```makefile
build:
	@[ -f api/clickupv3/client.gen.go ] || $(MAKE) api-gen
	go build ...
```

## Verification

```bash
git clone https://github.com/triptechtravel/clickup-cli && cd clickup-cli
rm -f api/clickupv2/*.gen.go api/clickupv3/*.gen.go internal/apiv*/operations.gen.go
make build   # triggers api-gen then builds successfully
```