### PR TITLE
feat(inbox): add --include-self flag to capture self-authored @mentions

### DIFF
--- a/pkg/cmd/inbox/cache.go
+++ b/pkg/cmd/inbox/cache.go
@@ -25,9 +25,12 @@ const (
 
 // inboxCache stores the date_updated of tasks observed in the workspace scan
 // so subsequent runs can skip the comment fetch for tasks that have not changed.
+// IncludeSelf records whether the cached mentions were captured with
+// self-authored mentions included, so a flag mismatch triggers a cold rescan.
 type inboxCache struct {
-	ScannedAt int64                      `json:"scanned_at"`
-	Tasks     map[string]inboxCacheEntry `json:"tasks"`
+	ScannedAt   int64                      `json:"scanned_at"`
+	IncludeSelf bool                       `json:"include_self"`
+	Tasks       map[string]inboxCacheEntry `json:"tasks"`
 }
 
 type inboxCacheEntry struct {

--- a/pkg/cmd/inbox/inbox.go
+++ b/pkg/cmd/inbox/inbox.go
@@ -17,11 +17,12 @@ import (
 )
 
 type inboxOptions struct {
-	factory   *cmdutil.Factory
-	days      int
-	limit     int
-	noCache   bool
-	jsonFlags cmdutil.JSONFlags
+	factory     *cmdutil.Factory
+	days        int
+	limit       int
+	noCache     bool
+	includeSelf bool
+	jsonFlags   cmdutil.JSONFlags
 }
 
 type mention struct {
@@ -115,6 +116,7 @@ approximates your inbox by combining these two endpoints.`,
 	cmd.Flags().IntVar(&opts.days, "days", 7, "How many days back to search")
 	cmd.Flags().IntVar(&opts.limit, "limit", 200, "Maximum number of tasks to scan for mentions")
 	cmd.Flags().BoolVar(&opts.noCache, "no-cache", false, "Bypass the local cache and re-fetch comments for every task")
+	cmd.Flags().BoolVar(&opts.includeSelf, "include-self", false, "Include @mentions where you authored the comment (useful for self-reminders)")
 	cmdutil.AddJSONFlags(cmd, &opts.jsonFlags)
 
 	return cmd
@@ -185,7 +187,7 @@ func inboxRun(opts *inboxOptions) error {
 			fmt.Fprintf(ios.ErrOut, "Warning: failed to load inbox cache: %v\n", err)
 			cache = &inboxCache{Tasks: map[string]inboxCacheEntry{}}
 		}
-		if !cache.IsFresh(time.Now()) {
+		if !cache.IsFresh(time.Now()) || cache.IncludeSelf != opts.includeSelf {
 			cache = &inboxCache{Tasks: map[string]inboxCacheEntry{}}
 		}
 	}
@@ -258,7 +260,8 @@ func inboxRun(opts *inboxOptions) error {
 		}
 
 		for _, c := range r.comments {
-			if containsMention(c.CommentText, username) && strings.ToLower(c.User.Username) != username {
+			isSelf := strings.ToLower(c.User.Username) == username
+			if containsMention(c.CommentText, username) && (opts.includeSelf || !isSelf) {
 				ms, _ := strconv.ParseInt(c.Date, 10, 64)
 				attachments := extractAttachmentURLs(c.Comment)
 				addMention(mention{
@@ -311,6 +314,7 @@ func inboxRun(opts *inboxOptions) error {
 	if cache == nil {
 		cache = &inboxCache{Tasks: map[string]inboxCacheEntry{}}
 	}
+	cache.IncludeSelf = opts.includeSelf
 	updateCacheFromTasks(cache, workspaceTasks, mentionsByTask, time.Now())
 	if err := saveInboxCache(cachePath, cache); err != nil {
 		fmt.Fprintf(ios.ErrOut, "Warning: failed to save inbox cache: %v\n", err)

--- a/pkg/cmd/inbox/inbox_test.go
+++ b/pkg/cmd/inbox/inbox_test.go
@@ -30,6 +30,51 @@ func TestNewCmdInbox_Defaults(t *testing.T) {
 	if limitFlag.DefValue != "200" {
 		t.Errorf("--limit default = %q, want %q", limitFlag.DefValue, "200")
 	}
+
+	includeSelfFlag := cmd.Flags().Lookup("include-self")
+	if includeSelfFlag == nil {
+		t.Fatal("expected --include-self flag")
+	}
+	if includeSelfFlag.DefValue != "false" {
+		t.Errorf("--include-self default = %q, want %q", includeSelfFlag.DefValue, "false")
+	}
+}
+
+func TestInboxCache_FlagMismatchInvalidates(t *testing.T) {
+	now := time.Now()
+	fresh := &inboxCache{
+		ScannedAt:   now.UnixMilli(),
+		IncludeSelf: false,
+		Tasks:       map[string]inboxCacheEntry{"a": {DateUpdated: "1"}},
+	}
+	if !fresh.IsFresh(now) {
+		t.Fatal("cache should be fresh by timestamp")
+	}
+	// The invalidation lives in inboxRun, but the cache field must round-trip
+	// through JSON so the next process sees the prior run's setting.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache.json")
+	if err := saveInboxCache(path, fresh); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err := loadInboxCache(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.IncludeSelf {
+		t.Error("IncludeSelf round-trip lost — expected false")
+	}
+	fresh.IncludeSelf = true
+	if err := saveInboxCache(path, fresh); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded, err = loadInboxCache(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !loaded.IncludeSelf {
+		t.Error("IncludeSelf=true did not round-trip")
+	}
 }
 
 func TestContainsMention_TaskDescriptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- `clickup inbox` silently filters out comments where the user @mentioned themselves, which hides a deliberate "remind myself later" workflow on teammates' tasks.
- Adds an opt-in `--include-self` flag that, when set, includes self-authored mentions alongside the normal incoming ones.
- Default behavior is unchanged: without the flag, the existing filter still applies. Zero impact on existing users.

## Implementation
- Filter at `pkg/cmd/inbox/inbox.go` rewritten as `if containsMention(...) && (opts.includeSelf || !isSelf)`.
- Cache round-trip: `inboxCache` gets a new `include_self` field. If the flag setting differs from the cached run's setting, the cache is treated as stale and a cold rescan kicks in. This avoids the case where a previous default-off run cached "no mentions" for tasks that actually have self-mentions.
- Test coverage:
  - `TestNewCmdInbox_Defaults` extended to assert the new flag exists and defaults to false.
  - `TestInboxCache_FlagMismatchInvalidates` covers the JSON round-trip of the new cache field.

## Test plan
- [x] `go test ./pkg/cmd/inbox/...` → 70 passed (69 prior + 1 new)
- [x] `go test ./...` → 751 passed across 45 packages
- [x] Manual: `clickup inbox --json --days 7 --include-self --no-cache` against a real workspace recovers self-authored @mentions that the default run omits
- [x] Manual: toggling `--include-self` between consecutive runs triggers a cache rescan as expected

- [x] I have assessed security implications of this change
- [x] I have tested this change (automating where feasible)
- [x] I have updated the documentation (where applicable)