### PR TITLE
feat(distribution): add curl | sh installer

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,52 @@
+name: Install script
+
+# Verifies the `curl | sh` installer still works. It downloads the latest
+# published release, so this catches two distinct classes of breakage:
+# changes to scripts/install.sh itself (PR trigger), and drift in the
+# release layout — renamed assets, a missing checksums.txt — which only
+# shows up after a release or on the weekly run.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/install.sh"
+      - "scripts/test-install.sh"
+      - ".github/workflows/install-test.yml"
+  pull_request:
+    paths:
+      - "scripts/install.sh"
+      - "scripts/test-install.sh"
+      - ".github/workflows/install-test.yml"
+  release:
+    types: [published]
+  schedule:
+    # Mondays 06:00 UTC — catches release-layout drift with no code change.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Shell/downloader/privilege matrix. Docker only covers Linux.
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./scripts/test-install.sh
+
+  # Docker can't test darwin, and macOS is the only place the `shasum`
+  # checksum branch and BSD tar get exercised.
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install to a temp dir
+        run: |
+          CLICKUP_INSTALL_DIR="$RUNNER_TEMP/bin" sh ./scripts/install.sh
+          "$RUNNER_TEMP/bin/clickup" version
+      - name: Install to the default location
+        run: |
+          sh ./scripts/install.sh
+          clickup version

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/internal/build.Commit=$(COMMIT) \
 	-X $(MODULE)/internal/build.Date=$(DATE)
 
-.PHONY: build install test lint clean smoke ensure-gen
+.PHONY: build install test lint clean smoke test-install ensure-gen
 
 ensure-gen:
 	@[ -f api/clickupv3/client.gen.go ] || $(MAKE) api-gen
@@ -28,6 +28,11 @@ test: ensure-gen
 # Override BIN to test a local build: `BIN=./bin/clickup make smoke`.
 smoke:
 	@./scripts/smoke.sh
+
+# Exercise scripts/install.sh across shells, downloaders, and privilege
+# levels in Docker. Filter with `./scripts/test-install.sh -k alpine`.
+test-install:
+	@./scripts/test-install.sh
 
 lint:
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A command-line tool for working with ClickUp tasks, comments, and sprints -- des
 ## Install
 
 ```sh
+# Install script (Linux and macOS)
+curl -fsSL https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh | sh
+
 # Homebrew
 brew install triptechtravel/tap/clickup
 
@@ -70,7 +73,7 @@ Full command list with flags and examples: **[Command reference](https://triptec
 
 **[triptechtravel.github.io/clickup-cli](https://triptechtravel.github.io/clickup-cli/)**
 
-- [Installation](https://triptechtravel.github.io/clickup-cli/installation/) -- Homebrew, Go, binaries, shell completions
+- [Installation](https://triptechtravel.github.io/clickup-cli/installation/) -- install script, Homebrew, Go, binaries, shell completions
 - [Getting started](https://triptechtravel.github.io/clickup-cli/getting-started/) -- first-time setup walkthrough
 - [Configuration](https://triptechtravel.github.io/clickup-cli/configuration/) -- config file, per-directory defaults, aliases
 - [Git integration](https://triptechtravel.github.io/clickup-cli/git-integration/) -- branch naming, GitHub linking strategy

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -1,9 +1,63 @@
 ---
 title: Installation
-description: Install the clickup CLI via Go, Homebrew, or binary release.
+description: Install the clickup CLI via the install script, Go, Homebrew, or binary release.
 ---
 
-There are three ways to install the `clickup` CLI.
+There are four ways to install the `clickup` CLI.
+
+## Install script
+
+On Linux and macOS, the quickest option:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh | sh
+```
+
+This detects your OS and architecture, downloads the matching release, verifies its SHA-256 checksum, and installs the binary to `/usr/local/bin` (falling back to `~/.local/bin` if that isn't writable).
+
+To review the script before running it — always a good idea for `curl | sh` — download it first:
+
+```sh
+curl -fsSL -o install.sh https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh
+less install.sh
+sh install.sh
+```
+
+The script honours a few environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `CLICKUP_VERSION` | Install a specific tag (e.g. `v0.35.1`) instead of the latest release. |
+| `CLICKUP_INSTALL_DIR` | Install to a specific directory. |
+| `CLICKUP_NO_SUDO` | Set to `1` to never escalate; installs to `~/.local/bin` instead. |
+
+```sh
+# Pin a version and install somewhere on your own PATH
+CLICKUP_VERSION=v0.35.1 CLICKUP_INSTALL_DIR="$HOME/bin" sh install.sh
+```
+
+Windows isn't supported by the script — use a [binary release](#binary-releases).
+
+### Supported platforms
+
+The script installs prebuilt binaries for Linux and macOS on `amd64` and `arm64`. On any other architecture it exits with a message telling you what's available.
+
+Because the binaries are statically linked with no libc dependency, a few environments work without any special handling:
+
+| Environment | Notes |
+| --- | --- |
+| **WSL2** | A normal Linux install — use the script as-is. |
+| **Docker and CI containers** | Works on Alpine and other musl-based images, not just glibc ones. |
+| **Raspberry Pi** | Works on 64-bit Raspberry Pi OS (`arm64`). The older 32-bit builds aren't supported. |
+| **Headless servers** | No desktop keyring required — see below. |
+
+On a machine with no OS keyring (a container, or a headless server without a D-Bus secret service), `clickup auth login` falls back to storing your token as plain text in the config directory and prints a warning. That's expected. In CI, pipe the token in from a secret rather than logging in interactively — see [CI usage](/clickup-cli/ci-usage/):
+
+```sh
+echo "$CLICKUP_TOKEN" | clickup auth login --with-token
+```
+
+Set `CLICKUP_CONFIG_DIR` to control where that config lives, which is useful for keeping it on a writable volume in a container.
 
 ## Go
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,187 @@
+#!/bin/sh
+# scripts/install.sh — one-line installer for the `clickup` CLI.
+#
+# Detects OS/arch, downloads the matching release tarball from GitHub,
+# verifies its SHA-256 against checksums.txt, and installs the binary.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh | sh
+#
+# Environment overrides:
+#   CLICKUP_VERSION      Tag to install (e.g. v0.35.1). Default: latest.
+#   CLICKUP_INSTALL_DIR  Target directory. Default: /usr/local/bin if
+#                        writable (or sudo is available), else ~/.local/bin.
+#   CLICKUP_BASE_URL     Release base URL. Override to test against a local
+#                        server instead of GitHub.
+#   CLICKUP_NO_SUDO      Set to 1 to never escalate; falls back to ~/.local/bin.
+#
+# POSIX sh on purpose: this runs under dash, busybox ash, and bash.
+
+set -eu
+
+REPO="triptechtravel/clickup-cli"
+BIN="clickup"
+VERSION="${CLICKUP_VERSION:-latest}"
+BASE_URL="${CLICKUP_BASE_URL:-https://github.com/${REPO}/releases}"
+
+TMPDIR_INSTALL=""
+
+log()  { printf '%s\n' "$*" >&2; }
+warn() { printf 'warning: %s\n' "$*" >&2; }
+die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+	[ -n "$TMPDIR_INSTALL" ] && rm -rf "$TMPDIR_INSTALL"
+}
+trap cleanup EXIT INT TERM
+
+# ── platform detection ────────────────────────────────────────────────
+
+detect_os() {
+	os="$(uname -s)"
+	case "$os" in
+		Linux)  printf 'linux' ;;
+		Darwin) printf 'darwin' ;;
+		*)      die "unsupported OS: $os (Windows users: download the .zip from ${BASE_URL})" ;;
+	esac
+}
+
+detect_arch() {
+	arch="$(uname -m)"
+	case "$arch" in
+		x86_64|amd64)   printf 'amd64' ;;
+		aarch64|arm64)  printf 'arm64' ;;
+		*)              die "unsupported architecture: $arch (available: amd64, arm64)" ;;
+	esac
+}
+
+# ── download helpers (curl or wget; busybox wget is enough) ───────────
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+download() {
+	# download <url> <dest>
+	if have curl; then
+		curl -fsSL "$1" -o "$2"
+	elif have wget; then
+		wget -q -O "$2" "$1"
+	else
+		die "need curl or wget to download files"
+	fi
+}
+
+sha256_of() {
+	# sha256_of <file> — print the bare hex digest
+	if have sha256sum; then
+		sha256sum "$1" | cut -d' ' -f1
+	elif have shasum; then
+		shasum -a 256 "$1" | cut -d' ' -f1
+	elif have openssl; then
+		openssl dgst -sha256 "$1" | awk '{print $NF}'
+	else
+		printf ''
+	fi
+}
+
+# ── install location ──────────────────────────────────────────────────
+
+# Sets SUDO to "sudo" when escalation is needed and possible, else "".
+resolve_install_dir() {
+	SUDO=""
+	if [ -n "${CLICKUP_INSTALL_DIR:-}" ]; then
+		INSTALL_DIR="$CLICKUP_INSTALL_DIR"
+		mkdir -p "$INSTALL_DIR" 2>/dev/null || die "cannot create $INSTALL_DIR"
+		[ -w "$INSTALL_DIR" ] || die "$INSTALL_DIR is not writable"
+		return
+	fi
+
+	default_dir="/usr/local/bin"
+	if [ -d "$default_dir" ] && [ -w "$default_dir" ]; then
+		INSTALL_DIR="$default_dir"
+		return
+	fi
+
+	if [ "${CLICKUP_NO_SUDO:-0}" != "1" ] && have sudo; then
+		# Only claim sudo if it works without prompting into a broken TTY.
+		if sudo -n true 2>/dev/null || [ -t 0 ]; then
+			INSTALL_DIR="$default_dir"
+			SUDO="sudo"
+			return
+		fi
+	fi
+
+	INSTALL_DIR="${HOME}/.local/bin"
+	mkdir -p "$INSTALL_DIR" || die "cannot create $INSTALL_DIR"
+}
+
+on_path() {
+	case ":${PATH}:" in
+		*":$1:"*) return 0 ;;
+		*)        return 1 ;;
+	esac
+}
+
+# ── main ──────────────────────────────────────────────────────────────
+
+main() {
+	os="$(detect_os)"
+	arch="$(detect_arch)"
+	asset="${BIN}_${os}_${arch}.tar.gz"
+
+	if [ "$VERSION" = "latest" ]; then
+		url="${BASE_URL}/latest/download/${asset}"
+		sums_url="${BASE_URL}/latest/download/checksums.txt"
+	else
+		url="${BASE_URL}/download/${VERSION}/${asset}"
+		sums_url="${BASE_URL}/download/${VERSION}/checksums.txt"
+	fi
+
+	TMPDIR_INSTALL="$(mktemp -d)"
+
+	log "Downloading ${asset} (${VERSION})..."
+	download "$url" "${TMPDIR_INSTALL}/${asset}" \
+		|| die "download failed: $url"
+
+	# Checksum verification is best-effort on the fetch (a release without
+	# checksums.txt shouldn't hard-fail), but a *mismatch* always aborts.
+	if download "$sums_url" "${TMPDIR_INSTALL}/checksums.txt" 2>/dev/null; then
+		expected="$(grep " ${asset}\$" "${TMPDIR_INSTALL}/checksums.txt" | cut -d' ' -f1 || true)"
+		actual="$(sha256_of "${TMPDIR_INSTALL}/${asset}")"
+		if [ -z "$actual" ]; then
+			warn "no sha256 tool found — skipping checksum verification"
+		elif [ -z "$expected" ]; then
+			warn "${asset} not listed in checksums.txt — skipping verification"
+		elif [ "$expected" != "$actual" ]; then
+			die "checksum mismatch for ${asset}
+  expected: ${expected}
+  actual:   ${actual}"
+		else
+			log "Checksum OK."
+		fi
+	else
+		warn "could not fetch checksums.txt — skipping verification"
+	fi
+
+	tar -xzf "${TMPDIR_INSTALL}/${asset}" -C "$TMPDIR_INSTALL" \
+		|| die "failed to extract ${asset}"
+	[ -f "${TMPDIR_INSTALL}/${BIN}" ] || die "${BIN} not found in archive"
+	chmod +x "${TMPDIR_INSTALL}/${BIN}"
+
+	resolve_install_dir
+	log "Installing to ${INSTALL_DIR}/${BIN}..."
+	$SUDO mkdir -p "$INSTALL_DIR"
+	$SUDO cp "${TMPDIR_INSTALL}/${BIN}" "${INSTALL_DIR}/${BIN}"
+
+	installed="$("${INSTALL_DIR}/${BIN}" version 2>/dev/null | head -1 || printf 'installed')"
+	log ""
+	log "✓ ${installed}"
+	log "  ${INSTALL_DIR}/${BIN}"
+
+	if ! on_path "$INSTALL_DIR"; then
+		log ""
+		warn "${INSTALL_DIR} is not on your PATH. Add it:"
+		log "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+	fi
+}
+
+main "$@"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# scripts/test-install.sh — exercise scripts/install.sh across environments.
+#
+# The installer is POSIX sh and has to survive shells and toolchains we don't
+# control, so the cases below deliberately vary the pieces most likely to
+# break it: busybox ash vs bash, wget vs curl, root vs unprivileged, and a
+# hermetic server that serves a deliberately corrupted tarball.
+#
+# Usage:
+#   make test-install              # all cases
+#   ./scripts/test-install.sh -k alpine   # only cases matching "alpine"
+#
+# Requires Docker. Network cases hit the real GitHub release; the checksum
+# cases are hermetic (local HTTP server inside the container).
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALLER="${ROOT}/scripts/install.sh"
+FILTER="${2:-}"
+PASS=0
+FAIL=0
+FAILED_CASES=()
+
+[ -f "$INSTALLER" ] || { echo "missing $INSTALLER" >&2; exit 1; }
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 1; }
+
+c_pass=$'\033[32m'; c_fail=$'\033[31m'; c_dim=$'\033[2m'; c_off=$'\033[0m'
+[ -t 1 ] || { c_pass=""; c_fail=""; c_dim=""; c_off=""; }
+
+# run_case <name> <image> <script> [platform]
+# The script runs inside the container with /install.sh mounted read-only.
+# Pass a platform (e.g. linux/amd64) for images without a native manifest.
+run_case() {
+	local name="$1" image="$2" script="$3" platform="${4:-}"
+
+	if [ -n "$FILTER" ] && [[ "$name" != *"$FILTER"* ]]; then
+		return
+	fi
+
+	local plat_args=()
+	[ -n "$platform" ] && plat_args=(--platform "$platform")
+
+	printf '%-38s' "$name"
+	local out
+	if out=$(docker run --rm "${plat_args[@]}" \
+		-v "${INSTALLER}:/install.sh:ro" \
+		"$image" sh -c "$script" 2>&1); then
+		printf '%sPASS%s\n' "$c_pass" "$c_off"
+		PASS=$((PASS + 1))
+	else
+		printf '%sFAIL%s\n' "$c_fail" "$c_off"
+		FAIL=$((FAIL + 1))
+		FAILED_CASES+=("$name")
+		printf '%s%s%s\n' "$c_dim" "$(echo "$out" | sed 's/^/    │ /' | tail -25)" "$c_off"
+	fi
+}
+
+echo "Testing scripts/install.sh"
+echo
+
+# ── shell / downloader matrix ─────────────────────────────────────────
+# alpine: busybox ash, busybox wget, no bash, no curl, no sudo, root.
+run_case "alpine (busybox ash + wget)" alpine:latest '
+	set -e
+	sh /install.sh
+	clickup version
+'
+
+run_case "debian (bash + curl)" debian:stable-slim '
+	set -e
+	apt-get -qq update && apt-get -qq install -y curl ca-certificates >/dev/null
+	sh /install.sh
+	clickup version
+'
+
+# Proves the wget branch works on a non-busybox wget too.
+run_case "debian (wget only, no curl)" debian:stable-slim '
+	set -e
+	apt-get -qq update && apt-get -qq install -y wget ca-certificates >/dev/null
+	sh /install.sh
+	clickup version
+'
+
+# Arch publishes x86_64 only, so this doubles as our amd64 coverage
+# (emulated when the host is arm64).
+run_case "archlinux (curl, amd64)" archlinux:latest '
+	set -e
+	sh /install.sh
+	clickup version
+' linux/amd64
+
+# ── privilege handling ────────────────────────────────────────────────
+# Unprivileged, no sudo: must fall back to ~/.local/bin rather than fail.
+run_case "non-root, no sudo -> ~/.local/bin" debian:stable-slim '
+	set -e
+	apt-get -qq update && apt-get -qq install -y curl ca-certificates >/dev/null
+	useradd -m tester
+	su tester -c "sh /install.sh"
+	test -x /home/tester/.local/bin/clickup
+	/home/tester/.local/bin/clickup version
+'
+
+run_case "CLICKUP_INSTALL_DIR override" alpine:latest '
+	set -e
+	CLICKUP_INSTALL_DIR=/opt/bin sh /install.sh
+	test -x /opt/bin/clickup
+	/opt/bin/clickup version
+'
+
+# ── version pinning ───────────────────────────────────────────────────
+run_case "CLICKUP_VERSION pinned tag" alpine:latest '
+	set -e
+	CLICKUP_VERSION=v0.35.0 sh /install.sh
+	clickup version | grep -q 0.35.0
+'
+
+# ── checksum verification (hermetic) ──────────────────────────────────
+# Build a fake release locally and serve it, so we can control the digest.
+# Case A: digest matches -> install succeeds.
+# Case B: digest is wrong -> install MUST abort and leave nothing behind.
+FAKE_RELEASE='
+	set -e
+	mkdir -p /srv/latest/download && cd /tmp
+	printf "#!/bin/sh\necho clickup version 9.9.9\n" > clickup
+	chmod +x clickup
+	tar czf /srv/latest/download/clickup_linux_$ARCH.tar.gz clickup
+	cd /srv && (python3 -m http.server 8000 >/dev/null 2>&1 &)
+	sleep 1
+'
+
+run_case "checksum valid (hermetic)" python:3-alpine "
+	ARCH=\$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+	$FAKE_RELEASE
+	sha256sum /srv/latest/download/clickup_linux_\$ARCH.tar.gz \
+		| sed 's|/srv/latest/download/||' > /srv/latest/download/checksums.txt
+	CLICKUP_BASE_URL=http://127.0.0.1:8000 sh /install.sh
+	clickup version | grep -q 9.9.9
+"
+
+run_case "checksum mismatch aborts" python:3-alpine "
+	ARCH=\$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+	$FAKE_RELEASE
+	echo \"$(printf '0%.0s' {1..64})  clickup_linux_\$ARCH.tar.gz\" > /srv/latest/download/checksums.txt
+	if CLICKUP_BASE_URL=http://127.0.0.1:8000 sh /install.sh 2>/tmp/err; then
+		echo 'BUG: installer succeeded despite bad checksum'; exit 1
+	fi
+	grep -q 'checksum mismatch' /tmp/err
+	if command -v clickup >/dev/null 2>&1; then
+		echo 'BUG: binary installed despite bad checksum'; exit 1
+	fi
+"
+
+# ── static analysis ───────────────────────────────────────────────────
+run_case "shellcheck (POSIX sh)" koalaman/shellcheck-alpine:stable '
+	shellcheck -s sh /install.sh
+'
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+	printf '%s%d passed%s\n' "$c_pass" "$PASS" "$c_off"
+else
+	printf '%s%d passed, %d failed%s\n' "$c_fail" "$PASS" "$FAIL" "$c_off"
+	printf '  failed: %s\n' "${FAILED_CASES[*]}"
+	exit 1
+fi


### PR DESCRIPTION
Adds a `curl | sh` installer for Linux and macOS — the install path that needs no package manager and no per-distro maintainer.

```sh
curl -fsSL https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh | sh
```

Raised as future work in #21; landing it standalone since it's independent of the AUR discussion.

## What it does

Detects OS/arch, downloads the matching release tarball, verifies its SHA-256 against `checksums.txt`, and installs to `/usr/local/bin` — falling back to `~/.local/bin` when that isn't writable or `sudo` isn't available.

Consumes the existing GoReleaser artifacts, so **the release pipeline is unchanged**. Version resolution uses GitHub's `/releases/latest/download/` path rather than the API, so there's no rate limit to hit and no JSON to parse.

Overrides: `CLICKUP_VERSION`, `CLICKUP_INSTALL_DIR`, `CLICKUP_NO_SUDO`, and `CLICKUP_BASE_URL` (used by the tests to point at a local server).

## Testing

`scripts/test-install.sh` (`make test-install`) runs the installer in Docker across the axes most likely to break a shell installer. All 10 pass locally:

| Case | Covers |
| --- | --- |
| alpine | busybox ash, busybox wget, no curl, no bash |
| debian + curl | the curl branch |
| debian, wget only | the wget branch on a non-busybox wget |
| archlinux `linux/amd64` | Arch is x86_64-only, so this doubles as amd64 coverage |
| non-root, no sudo | asserts the `~/.local/bin` fallback |
| `CLICKUP_INSTALL_DIR` / `CLICKUP_VERSION` | overrides |
| checksum valid (hermetic) | local server, known-good digest |
| checksum mismatch (hermetic) | **must abort and leave no binary behind** |
| shellcheck | `-s sh` |

Two things Docker can't cover, handled in CI:

- **macOS** — no darwin containers, and it's the only place `shasum -a 256` (there's no `sha256sum`) and BSD tar run. `macos-latest` job.
- **Release-layout drift** — the installer depends on asset names and `checksums.txt` existing, which can break with zero code change (e.g. editing `name_template` in `.goreleaser.yml`). The workflow runs on `release: published` and weekly to catch that.

## Docs

New "Install script" section in `installation.md` plus a **Supported platforms** subsection documenting coverage that already existed but wasn't written down: WSL2, Docker/CI on musl images (the binaries are static, `CGO_ENABLED=0`), 64-bit Raspberry Pi OS, and the plaintext-token fallback on machines with no OS keyring.

No changes to the binary. No impact on Homebrew, `go install`, or binary-release users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
