### PR TITLE
ci: verify the install script against each published release

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -4,7 +4,12 @@ name: Install script
 # published release, so this catches two distinct classes of breakage:
 # changes to scripts/install.sh itself (PR trigger), and drift in the
 # release layout — renamed assets, a missing checksums.txt — which only
-# shows up after a release or on the weekly run.
+# shows up on the weekly run.
+#
+# Post-release verification deliberately lives in release.yml instead of a
+# `release: published` trigger here: GoReleaser publishes with GITHUB_TOKEN,
+# and events from that token never start a workflow run, so the trigger
+# would look like coverage while never firing.
 
 on:
   push:
@@ -18,8 +23,6 @@ on:
       - "scripts/install.sh"
       - "scripts/test-install.sh"
       - ".github/workflows/install-test.yml"
-  release:
-    types: [published]
   schedule:
     # Mondays 06:00 UTC — catches release-layout drift with no code change.
     - cron: "0 6 * * 1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  # Prove the install script works against the release we just cut.
+  #
+  # This lives here rather than as a `release: published` trigger on the
+  # install-script workflow because GoReleaser publishes using GITHUB_TOKEN,
+  # and events created by that token never trigger new workflow runs — so
+  # such a trigger silently never fires. Hanging it off `needs: goreleaser`
+  # makes the ordering explicit and the run guaranteed.
+  verify-install:
+    needs: goreleaser
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install the tag we just released
+        run: |
+          CLICKUP_VERSION="${GITHUB_REF_NAME}" sh ./scripts/install.sh
+          clickup version | grep -F "${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
Follow-up to #22.

That PR added a `release: published` trigger to the install-script workflow so release-layout drift would be caught the moment it happens. **It never fires.** GoReleaser publishes using `GITHUB_TOKEN`, and [events created by that token do not trigger new workflow runs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). Confirmed empirically against v0.36.0 — zero release-triggered runs.

Worse than missing coverage: it *looked* like coverage.

## Fix

Move the check into `release.yml` as a `verify-install` job with `needs: goreleaser`, so ordering is explicit and the run is guaranteed. It installs the exact tag just published (not `latest`) on both `ubuntu-latest` and `macos-latest`, and asserts the reported version matches the tag.

The weekly schedule and path-based PR triggers in `install-test.yml` are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)