### PR TITLE
docs: surface the install script on the landing page

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -190,8 +190,14 @@ Releases use [GoReleaser](https://goreleaser.com/) via GitHub Actions:
 2. Push the tag: `git push origin v0.x.0`
 3. GitHub Actions runs `make api-gen`, builds binaries for all platforms
 4. Homebrew formula is auto-updated in `triptechtravel/homebrew-tap`
+5. The `verify-install` job installs the new tag via `scripts/install.sh` on
+   Linux and macOS, so a broken release surfaces immediately
 
 Install: `brew install triptechtravel/tap/clickup`
+
+To exercise the install script without cutting a release, run `make test-install`
+(requires Docker). It runs the installer across shells, downloaders, and
+privilege levels, and asserts it aborts on a checksum mismatch.
 
 ## License
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -66,8 +66,10 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Quick install
 
+On Linux and macOS, with no toolchain required:
+
 ```sh
-go install github.com/triptechtravel/clickup-cli/cmd/clickup@latest
+curl -fsSL https://raw.githubusercontent.com/triptechtravel/clickup-cli/main/scripts/install.sh | sh
 ```
 
 Or via Homebrew:
@@ -76,7 +78,13 @@ Or via Homebrew:
 brew install triptechtravel/tap/clickup
 ```
 
-See the [Installation](/clickup-cli/installation/) page for all options.
+Or with Go 1.25+:
+
+```sh
+go install github.com/triptechtravel/clickup-cli/cmd/clickup@latest
+```
+
+See the [Installation](/clickup-cli/installation/) page for all options, including Windows and prebuilt binaries.
 
 ## Quick start
 


### PR DESCRIPTION
Follow-up to #22 and #23.

#22 updated `README.md` and `installation.md`, but missed that `index.mdx` — the docs **landing page** — carries its own `## Quick install` block. The fastest install path was therefore absent from the page most readers hit first.

- **`index.mdx`** — lead with the install script, then order by prerequisites: script (none) → Homebrew → Go.
- **`contributing.md`** — the release-process list didn't mention the `verify-install` job added in #23. Also points contributors at `make test-install`.

Docs-only. `make docs` leaves the generated `reference/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)